### PR TITLE
CD 스테이징(dev/prod) 분리 및 자동 배포 파이프라인 구성

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,19 +1,23 @@
 # GitHub Actions 워크플로우의 이름
-name: Deploy to AWS Lambda (dev)
+name: Deploy to AWS Lambda
 
 # 워크플로우가 실행될 조건 (트리거)
 on:
   push:
     branches:
-      - dev # prod, dev 스테이지로 이후에 나눌 예정
+      - dev
+      - prod
 
 # 실행될 작업(Job)들의 목록
 jobs:
   deploy:
     # 작업의 이름
-    name: Build and Deploy
+    name: Build and Deploy to ${{ github.ref_name }}
     # 작업이 실행될 가상 환경
     runs-on: ubuntu-latest
+    # 환경변수 설정
+    env:
+      STAGE: ${{ github.ref_name == 'prod' && 'prod' || 'dev' }}
 
     # 작업의 단계(Step)들
     steps:
@@ -48,12 +52,19 @@ jobs:
           npm install -g serverless@3
           npm install
 
-      # 6. 환경 변수 파일 생성
-      # GitHub Secrets를 사용하여 배포에 필요한 config.dev.json 파일을 동적으로 생성
-      - name: Create environment file
+      # 6-1. dev 환경 설정 파일 생성
+      - name: Create DEV environment file
+        if: env.STAGE == 'dev'
         run: |
           mkdir -p envs
-          echo '{ "development": { "SUPABASE_URL": "${{ secrets.SUPABASE_URL }}", "SUPABASE_API_KEY": "${{ secrets.SUPABASE_API_KEY }}" } }' > envs/config.dev.json
+          echo '{ "SUPABASE_URL": "${{ secrets.SUPABASE_URL }}", "SUPABASE_API_KEY": "${{ secrets.SUPABASE_API_KEY }}" }' > envs/config.dev.json
+
+      # 6-2. prod 환경 설정 파일 생성 (이후 실제 PROD DB 연결이 필요함)
+      - name: Create PROD environment file
+        if: env.STAGE == 'prod'
+        run: |
+          mkdir -p envs
+          echo '{ "SUPABASE_URL": "${{ secrets.PROD_SUPABASE_URL }}", "SUPABASE_API_KEY": "${{ secrets.PROD_SUPABASE_API_KEY }}" }' > envs/config.prod.json
 
       # 7. Python Lambda Layer 빌드
       # 우리가 찾은, Docker 없이 Linux 호환 라이브러리를 설치하는 명령어 실행
@@ -72,5 +83,5 @@ jobs:
           ls -la layer/python/ | head -5
 
       # 8. Serverless Framework를 사용하여 AWS에 배포
-      - name: Deploy to AWS
-        run: sls deploy --stage dev
+      - name: Deploy to AWS (${{ env.STAGE }})
+        run: sls deploy --stage ${{ env.STAGE }}

--- a/serverless.yml
+++ b/serverless.yml
@@ -33,8 +33,8 @@ provider:
     cors: true
   environment:
     STAGE: ${self:provider.stage}
-    SUPABASE_URL: ${file(envs/config.${self:provider.stage}.json):development.SUPABASE_URL}
-    SUPABASE_API_KEY: ${file(envs/config.${self:provider.stage}.json):development.SUPABASE_API_KEY}
+    SUPABASE_URL: ${file(envs/config.${self:provider.stage}.json):SUPABASE_URL}
+    SUPABASE_API_KEY: ${file(envs/config.${self:provider.stage}.json):SUPABASE_API_KEY}
 
 layers:
   AppDependencies:
@@ -46,6 +46,7 @@ layers:
 
 functions:
   getRooms:
+    name: ${self:provider.stage}-api-getRooms
     handler: src.handlers.rooms_handler.get_all
     layers:
       - { Ref: AppDependenciesLambdaLayer }

--- a/serverless.yml
+++ b/serverless.yml
@@ -56,6 +56,7 @@ functions:
           path: /rooms
 
   getNotices:
+    name: ${self:provider.stage}-api-getNotices
     handler: src.handlers.notices_handler.get_all
     layers:
       - { Ref: AppDependenciesLambdaLayer }
@@ -65,6 +66,7 @@ functions:
           path: /notices
 
   getNoticeById:
+    name: ${self:provider.stage}-api-getNoticeByID
     handler: src.handlers.notices_handler.get_one
     layers:
       - { Ref: AppDependenciesLambdaLayer }


### PR DESCRIPTION
### 개요
- **브랜치 기반 스테이징(dev/prod)** 자동 배포 파이프라인을 구성했습니다.
- 환경별 Supabase 설정을 분리했습니다.
- 추가 작업 : Lambda 함수 네이밍을 스테이지 프리픽스 방식으로 통일했습니다.

### 주요 변경사항
- **`.github/workflows/deploy.yml`**
  - 트리거: `dev`, `prod`
  - 환경 변수: `STAGE`를 브랜치에 따라 `dev`/`prod`로 설정
  - 환경 파일 생성:
    - dev → `envs/config.dev.json` (Secrets: `SUPABASE_URL`, `SUPABASE_API_KEY`)
    - prod → `envs/config.prod.json` (Secrets: `PROD_SUPABASE_URL`, `PROD_SUPABASE_API_KEY`)

- **`serverless.yml`**
  - 환경 변수: `envs/config.${stage}.json`에서 `SUPABASE_URL`, `SUPABASE_API_KEY` 주입
  - 함수 네이밍 통일: `${stage}-api-...`
    - `getRooms` → `${stage}-api-getRooms`
    - `getNotices` → `${stage}-api-getNotices`
    - `getNoticeById` → `${stage}-api-getNoticeByID`

### 동작 방식
- dev 브랜치 푸시 → dev 스테이지에 배포 (dev Secrets 사용)
- prod 브랜치 푸시 → prod 스테이지에 배포 (prod Secrets 사용)
- 애플리케이션 코드는 동일한 키(`SUPABASE_URL`, `SUPABASE_API_KEY`)만 참조

### 필요한 GitHub Secrets
- 공통(dev): `SUPABASE_URL`, `SUPABASE_API_KEY`
- 프로덕션(prod): `PROD_SUPABASE_URL`, `PROD_SUPABASE_API_KEY`
- AWS: `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`

### 테스트 방법
- dev 배포: dev 브랜치에 사소한 커밋 푸시 → Actions 확인 → Lambda/HTTP API 확인
- prod 배포: prod 브랜치 푸시 → Actions 확인 → Lambda/HTTP API 확인

### 비고
- 현재 prod DB 가 생성되었음