### PR TITLE
feat: 공지사항 삭제 API 구현 (DELETE /notice)

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -104,3 +104,13 @@ functions:
       - httpApi:
           method: post
           path: /notice
+
+  deleteNotice:
+    name: ${self:provider.stage}-api-deleteNotice
+    handler: src.handlers.notices_handler.delete
+    layers:
+      - { Ref: AppDependenciesLambdaLayer }
+    events:
+      - httpApi:
+          method: delete
+          path: /notice

--- a/src/dto/__init__.py
+++ b/src/dto/__init__.py
@@ -1,18 +1,24 @@
 # DTO 패키지 초기화 파일
 from .base_dto import BaseDTO, ErrorDTO, SuccessDTO
 from .room_dto import RoomDTO, RoomListDTO
-from .notice_dto import NoticeDTO, NoticeListDTO, NoticeCreateRequestDTO
+from .notice_dto import (
+    NoticeDTO,
+    NoticeListDTO,
+    NoticeCreateRequestDTO,
+    NoticeDeleteRequestDTO,
+)
 from .student_dto import StudentDTO, StudentListDTO
 
 __all__ = [
-    'BaseDTO',
-    'ErrorDTO', 
-    'SuccessDTO',
-    'RoomDTO',
-    'RoomListDTO',
-    'NoticeDTO',
-    'NoticeListDTO',
-    'NoticeCreateRequestDTO',
-    'StudentDTO',
-    'StudentListDTO'
+    "BaseDTO",
+    "ErrorDTO",
+    "SuccessDTO",
+    "RoomDTO",
+    "RoomListDTO",
+    "NoticeDTO",
+    "NoticeListDTO",
+    "NoticeCreateRequestDTO",
+    "NoticeDeleteRequestDTO",
+    "StudentDTO",
+    "StudentListDTO",
 ]

--- a/src/dto/notice_dto.py
+++ b/src/dto/notice_dto.py
@@ -1,6 +1,7 @@
 """
 공지사항 관련 DTO 클래스들을 정의합니다.
 """
+
 from typing import Optional
 from dataclasses import dataclass
 from .base_dto import BaseDTO
@@ -9,10 +10,11 @@ from .base_dto import BaseDTO
 @dataclass
 class NoticeCreateRequestDTO(BaseDTO):
     """공지사항 생성 요청 DTO"""
+
     title: str
     content: str
     is_important: bool = False
-    
+
     def validate(self) -> tuple[bool, Optional[str]]:
         """요청 데이터 검증"""
         if not self.title or not self.title.strip():
@@ -25,35 +27,50 @@ class NoticeCreateRequestDTO(BaseDTO):
 @dataclass
 class NoticeDTO(BaseDTO):
     """공지사항 응답 DTO"""
+
     id: int
     title: str
     content: str
     date: str  # created_at → date 변환
     is_important: bool
-    
+
     @classmethod
-    def from_supabase_data(cls, data: dict) -> 'NoticeDTO':
+    def from_supabase_data(cls, data: dict) -> "NoticeDTO":
         """Supabase 데이터에서 NoticeDTO 생성"""
         return cls(
             id=data["id"],
             title=data["title"],
             content=data["content"],
             date=data["created_at"],  # created_at → date 변환
-            is_important=data["is_important"]
+            is_important=data["is_important"],
         )
 
 
 @dataclass
 class NoticeListDTO(BaseDTO):
     """공지사항 목록 응답 DTO"""
+
     notices: list[NoticeDTO]
-    
+
     def to_dict(self) -> dict:
         """공지사항 목록을 딕셔너리 리스트로 변환"""
         return [notice.to_dict() for notice in self.notices]
-    
+
     @classmethod
-    def from_supabase_data(cls, data_list: list[dict]) -> 'NoticeListDTO':
+    def from_supabase_data(cls, data_list: list[dict]) -> "NoticeListDTO":
         """Supabase 데이터 리스트에서 NoticeListDTO 생성"""
         notices = [NoticeDTO.from_supabase_data(data) for data in data_list]
         return cls(notices=notices)
+
+
+@dataclass
+class NoticeDeleteRequestDTO(BaseDTO):
+    """공지사항 삭제 요청 DTO"""
+
+    id: int
+
+    def validate(self) -> tuple[bool, Optional[str]]:
+        """요청 데이터 검증"""
+        if not isinstance(self.id, int) or self.id <= 0:
+            return False, "ID must be a positive integer."
+        return True, None

--- a/src/handlers/notices_handler.py
+++ b/src/handlers/notices_handler.py
@@ -2,7 +2,12 @@ import logging
 import json
 from src.services import notices_service
 from src.utils import responses
-from src.dto import NoticeListDTO, NoticeDTO, NoticeCreateRequestDTO
+from src.dto import (
+    NoticeListDTO,
+    NoticeDTO,
+    NoticeCreateRequestDTO,
+    NoticeDeleteRequestDTO,
+)
 
 # 로거 설정
 logger = logging.getLogger()
@@ -45,7 +50,7 @@ def create(event, context):
         request_dto = NoticeCreateRequestDTO(
             title=body.get("title", ""),
             content=body.get("content", ""),
-            is_important=body.get("is_important", False)
+            is_important=body.get("is_important", False),
         )
 
         # 요청 데이터 검증
@@ -55,9 +60,7 @@ def create(event, context):
 
         # 공지사항 생성
         notice_data, error = notices_service.create_notice(
-            request_dto.title, 
-            request_dto.content, 
-            request_dto.is_important
+            request_dto.title, request_dto.content, request_dto.is_important
         )
 
         if error:
@@ -84,26 +87,68 @@ def get_paginated(event, context):
         # 쿼리 파라미터에서 페이지 번호 추출
         query_params = event.get("queryStringParameters") or {}
         page_str = query_params.get("page", "1")
-        
+
         # 페이지 번호 검증 및 변환
         try:
             page = int(page_str)
             if page < 1:
-                return responses.create_error_response("Page number must be greater than 0.", 400)
+                return responses.create_error_response(
+                    "Page number must be greater than 0.", 400
+                )
         except ValueError:
             return responses.create_error_response("Invalid page number format.", 400)
 
         # 페이지네이션된 공지사항 조회
-        notices_data, total_count, error = notices_service.get_notices_with_pagination(page=page)
+        notices_data, total_count, error = notices_service.get_notices_with_pagination(
+            page=page
+        )
 
         if error:
             return responses.create_error_response(error, 500)
 
         # DTO를 사용하여 응답 데이터 변환 (기존 NoticeListDTO 사용)
         notice_list_dto = NoticeListDTO.from_supabase_data(notices_data)
-        
+
         return responses.create_success_response(notice_list_dto.to_dict())
 
     except Exception as e:
         logger.error(f"❌ 페이지네이션 공지사항 조회 실패: {e}")
+        return responses.create_error_response("Internal server error.", 500)
+
+
+def delete(event, context):
+    """
+    DELETE /notices API 요청을 처리하는 핸들러
+    """
+    logger.info("✅ Processing delete notice request")
+
+    try:
+        # 요청 본문 파싱
+        body = json.loads(event.get("body", "{}"))
+
+        # DTO를 사용하여 요청 데이터 검증
+        request_dto = NoticeDeleteRequestDTO(id=body.get("id"))
+
+        # 요청 데이터 검증
+        is_valid, error_message = request_dto.validate()
+        if not is_valid:
+            return responses.create_error_response(error_message, 400)
+
+        # 공지사항 삭제
+        _, error = notices_service.delete_notice_by_id(request_dto.id)
+
+        if error:
+            if error == "Notice not found":
+                return responses.create_error_response(error, 404)
+            return responses.create_error_response(error, 500)
+
+        # 성공 응답 반환
+        return responses.create_success_response(
+            {"message": "Notice deleted successfully"}
+        )
+
+    except json.JSONDecodeError:
+        return responses.create_error_response("Invalid JSON format.", 400)
+    except Exception as e:
+        logger.error(f"❌ 공지사항 삭제 실패: {e}")
         return responses.create_error_response("Internal server error.", 500)

--- a/src/services/notices_service.py
+++ b/src/services/notices_service.py
@@ -85,13 +85,15 @@ def get_notices_with_pagination(page: int = 1):
     페이지당 10개의 공지사항을 반환합니다.
     """
     PAGE_SIZE = 10
-    
+
     try:
         supabase = get_supabase_client("core")
         if not supabase:
             return None, None, "Supabase client could not be initialized."
 
-        logger.info(f"Supabase 'notice' 테이블 페이지네이션 조회 시작 - 페이지: {page}, 크기: {PAGE_SIZE}")
+        logger.info(
+            f"Supabase 'notice' 테이블 페이지네이션 조회 시작 - 페이지: {page}, 크기: {PAGE_SIZE}"
+        )
 
         # 페이지네이션 계산
         offset = (page - 1) * PAGE_SIZE
@@ -127,3 +129,38 @@ def get_notices_with_pagination(page: int = 1):
         logger.error(f"❌ Supabase API 호출 실패: {e}")
         error_message = getattr(e, "message", str(e))
         return None, None, error_message
+
+
+def delete_notice_by_id(notice_id: int):
+    """
+    Supabase 클라이언트를 사용하여 특정 공지사항을 삭제합니다.
+    """
+    try:
+        supabase = get_supabase_client("core")
+        if not supabase:
+            return None, "Supabase client could not be initialized."
+
+        logger.info(f"Supabase 'notice' 테이블에서 ID {notice_id} 삭제 시작")
+
+        response = (
+            supabase.postgrest.schema("core")
+            .from_("notice")
+            .delete()
+            .eq("id", notice_id)
+            .execute()
+        )
+
+        # 삭제된 데이터가 있는지 확인
+        if not response.data:
+            logger.warning(f"삭제할 공지사항 ID {notice_id}를 찾을 수 없습니다.")
+            return None, "Notice not found"
+
+        logger.info(f"✅ 공지사항 ID {notice_id}가 성공적으로 삭제되었습니다.")
+
+        # 삭제 성공 시 반환되는 데이터는 삭제된 레코드의 리스트
+        return response.data, None
+
+    except Exception as e:
+        logger.error(f"❌ Supabase API 호출 실패: {e}")
+        error_message = getattr(e, "message", str(e))
+        return None, error_message


### PR DESCRIPTION
### 📝 변경 사항
공지사항(Notice) CRUD 기능 중 삭제(Delete) 기능을 구현했습니다.

### 🔧 구현 내용

#### 1. DTO 추가
- `src/dto/notice_dto.py`에 `NoticeDeleteRequestDTO` 클래스 추가
- 삭제 요청 데이터 검증 로직 포함

#### 2. 서비스 로직 구현
- `src/services/notices_service.py`에 `delete_notice_by_id()` 함수 추가
- Supabase를 통한 공지사항 삭제 로직 구현
- 삭제된 데이터 존재 여부 확인 및 에러 처리

#### 3. API 핸들러 구현
- `src/handlers/notices_handler.py`에 `delete()` 핸들러 함수 추가
- JSON 요청 본문 파싱 및 DTO 검증

#### 4. API 엔드포인트 설정
- `serverless.yml`에 `deleteNotice` 함수 및 `DELETE /notice` 엔드포인트 추가

#### 5. 패키지 설정 업데이트
- `src/dto/__init__.py`에 `NoticeDeleteRequestDTO` import 추가

### 📋 API 명세

**엔드포인트**: `DELETE /notice`

**요청 본문**:
```json
{
  "id": 1
}
```

**응답 형식**:
```json
{
    "message": "Notice deleted successfully"
}
```