### PR TITLE
feat: 공지사항 수정 API 구현 (PUT /notice)

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -114,3 +114,13 @@ functions:
       - httpApi:
           method: delete
           path: /notice
+
+  updateNotice:
+    name: ${self:provider.stage}-api-updateNotice
+    handler: src.handlers.notices_handler.update
+    layers:
+      - { Ref: AppDependenciesLambdaLayer }
+    events:
+      - httpApi:
+          method: put
+          path: /notice

--- a/src/dto/__init__.py
+++ b/src/dto/__init__.py
@@ -6,6 +6,7 @@ from .notice_dto import (
     NoticeListDTO,
     NoticeCreateRequestDTO,
     NoticeDeleteRequestDTO,
+    NoticeUpdateRequestDTO,
 )
 from .student_dto import StudentDTO, StudentListDTO
 
@@ -19,6 +20,7 @@ __all__ = [
     "NoticeListDTO",
     "NoticeCreateRequestDTO",
     "NoticeDeleteRequestDTO",
+    "NoticeUpdateRequestDTO",
     "StudentDTO",
     "StudentListDTO",
 ]

--- a/src/dto/notice_dto.py
+++ b/src/dto/notice_dto.py
@@ -74,3 +74,23 @@ class NoticeDeleteRequestDTO(BaseDTO):
         if not isinstance(self.id, int) or self.id <= 0:
             return False, "ID must be a positive integer."
         return True, None
+
+
+@dataclass
+class NoticeUpdateRequestDTO(BaseDTO):
+    """공지사항 수정 요청 DTO"""
+
+    id: int
+    title: str
+    content: str
+    is_important: bool = False
+
+    def validate(self) -> tuple[bool, Optional[str]]:
+        """요청 데이터 검증"""
+        if not isinstance(self.id, int) or self.id <= 0:
+            return False, "ID must be a positive integer."
+        if not self.title or not self.title.strip():
+            return False, "Title is required."
+        if not self.content or not self.content.strip():
+            return False, "Content is required."
+        return True, None

--- a/src/handlers/notices_handler.py
+++ b/src/handlers/notices_handler.py
@@ -7,6 +7,7 @@ from src.dto import (
     NoticeDTO,
     NoticeCreateRequestDTO,
     NoticeDeleteRequestDTO,
+    NoticeUpdateRequestDTO,
 )
 
 # 로거 설정
@@ -151,4 +152,51 @@ def delete(event, context):
         return responses.create_error_response("Invalid JSON format.", 400)
     except Exception as e:
         logger.error(f"❌ 공지사항 삭제 실패: {e}")
+        return responses.create_error_response("Internal server error.", 500)
+
+
+def update(event, context):
+    """
+    PUT /notice API 요청을 처리하는 핸들러
+    """
+    logger.info("✅ Processing update notice request")
+
+    try:
+        # 요청 본문 파싱
+        body = json.loads(event.get("body", "{}"))
+
+        # DTO를 사용하여 요청 데이터 검증
+        request_dto = NoticeUpdateRequestDTO(
+            id=body.get("id"),
+            title=body.get("title", ""),
+            content=body.get("content", ""),
+            is_important=body.get("is_important", False),
+        )
+
+        # 요청 데이터 검증
+        is_valid, error_message = request_dto.validate()
+        if not is_valid:
+            return responses.create_error_response(error_message, 400)
+
+        # 공지사항 수정
+        notice_data, error = notices_service.update_notice_by_id(
+            request_dto.id,
+            request_dto.title,
+            request_dto.content,
+            request_dto.is_important,
+        )
+
+        if error:
+            if error == "Notice not found":
+                return responses.create_error_response(error, 404)
+            return responses.create_error_response(error, 500)
+
+        # DTO를 사용하여 응답 데이터 변환
+        notice_dto = NoticeDTO.from_supabase_data(notice_data)
+        return responses.create_success_response(notice_dto.to_dict())
+
+    except json.JSONDecodeError:
+        return responses.create_error_response("Invalid JSON format.", 400)
+    except Exception as e:
+        logger.error(f"❌ 공지사항 수정 실패: {e}")
         return responses.create_error_response("Internal server error.", 500)

--- a/src/services/notices_service.py
+++ b/src/services/notices_service.py
@@ -164,3 +164,44 @@ def delete_notice_by_id(notice_id: int):
         logger.error(f"❌ Supabase API 호출 실패: {e}")
         error_message = getattr(e, "message", str(e))
         return None, error_message
+
+
+def update_notice_by_id(
+    notice_id: int, title: str, content: str, is_important: bool = False
+):
+    """
+    Supabase 클라이언트를 사용하여 특정 공지사항을 수정합니다.
+    """
+    try:
+        supabase = get_supabase_client("core")
+        if not supabase:
+            return None, "Supabase client could not be initialized."
+
+        logger.info(f"Supabase 'notice' 테이블에서 ID {notice_id} 수정 시작")
+
+        # 수정할 데이터 준비
+        update_data = {"title": title, "content": content, "is_important": is_important}
+
+        response = (
+            supabase.postgrest.schema("core")
+            .from_("notice")
+            .update(update_data)
+            .eq("id", notice_id)
+            .execute()
+        )
+
+        # 수정된 데이터가 있는지 확인
+        if not response.data:
+            logger.warning(f"수정할 공지사항 ID {notice_id}를 찾을 수 없습니다.")
+            return None, "Notice not found"
+
+        updated_notice = response.data[0]
+        logger.info(f"✅ 공지사항 ID {notice_id}가 성공적으로 수정되었습니다.")
+
+        # 원시 데이터를 그대로 반환 (DTO 변환은 핸들러에서 처리)
+        return updated_notice, None
+
+    except Exception as e:
+        logger.error(f"❌ Supabase API 호출 실패: {e}")
+        error_message = getattr(e, "message", str(e))
+        return None, error_message


### PR DESCRIPTION
### ⁉️ 변경 사항
공지사항(Notice) CRUD 기능 중 수정(Update) 기능을 구현했습니다. 이제 공지사항의 제목, 내용, 중요도 표시를 수정할 수 있습니다.

### 🔧 구현 내용

#### 1. DTO 추가
- `src/dto/notice_dto.py`에 `NoticeUpdateRequestDTO` 클래스 추가
- 수정 요청 데이터 검증 로직 포함 (ID 양수, 제목/내용 필수 검증)

#### 2. 서비스 로직 구현
- `src/services/notices_service.py`에 `update_notice_by_id()` 함수 추가
- Supabase를 통한 공지사항 수정 로직 구현
- 수정된 데이터 존재 여부 확인 및 에러 처리

#### 3. API 핸들러 구현
- `src/handlers/notices_handler.py`에 `update()` 핸들러 함수 추가
- JSON 요청 본문 파싱 및 DTO 검증

#### 4. API 엔드포인트 설정
- `serverless.yml`에 `updateNotice` 함수 및 `PUT /notice` 엔드포인트 추가

#### 5. 패키지 설정 업데이트
- `src/dto/__init__.py`에 `NoticeUpdateRequestDTO` import 추가

### API 명세

**엔드포인트**: `PUT /notice`

**요청 본문**:
```json
{
  "id": 1,
  "title": "수정된 제목",
  "content": "수정된 내용",
  "is_important": true
}
```

**응답**:

  ```json
  {
    "id": 1,
    "title": "수정된 제목",
    "content": "수정된 내용",
    "date": "2025-01-15T10:30:00Z",
    "is_important": true
  }
  ```

### 🙌 현재 공지사항 API 완성도
이제 공지사항 CRUD 기능이 모두 완성되었습니다:

- ✅ **C**reate: `POST /notice` - 공지사항 생성
- ✅ **R**ead: `GET /notices` (목록), `GET /notice?id={id}` (단일 조회)
- ✅ **U**pdate: `PUT /notice` - 공지사항 수정
- ✅ **D**elete: `DELETE /notice` - 공지사항 삭제