### PR TITLE
fix: GET /students/{roomNumber} API 수정

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -93,7 +93,7 @@ functions:
     events:
       - httpApi:
           method: get
-          path: /students/{roomId}
+          path: /students/{roomNumber}
 
   createNotice:
     name: ${self:provider.stage}-api-createNotice

--- a/src/dto/room_dto.py
+++ b/src/dto/room_dto.py
@@ -12,7 +12,6 @@ class RoomDTO(BaseDTO):
     """호실 응답 DTO"""
 
     id: int
-    name: str
     floor: int
     headcount: int
 
@@ -20,8 +19,7 @@ class RoomDTO(BaseDTO):
     def from_supabase_data(cls, data: dict) -> "RoomDTO":
         """Supabase 데이터에서 RoomDTO 생성"""
         return cls(
-            id=data["id"],
-            name=data["room_number"],  # room_number → name 변환
+            id=data["room_number"],
             floor=data["floor"],
             headcount=data["capacity"],  # capacity → headcount 변환
         )

--- a/src/dto/student_dto.py
+++ b/src/dto/student_dto.py
@@ -16,7 +16,7 @@ class StudentDTO(BaseDTO):
     studentIdNum: str = ""  # studentNo → studentIdNum 변환
     affiliation: Optional[str] = None
     major: Optional[str] = None
-    roomId: Optional[str] = None  # room_id → roomId 변환
+    roomNumber: Optional[str] = None  # room_nuber → roomNumber 변환
 
     @classmethod
     def from_supabase_data(cls, data: dict) -> "StudentDTO":
@@ -27,7 +27,7 @@ class StudentDTO(BaseDTO):
             studentIdNum=data["studentNo"],  # studentNo → studentIdNum 변환
             affiliation=data.get("affiliation"),
             major=data.get("major"),
-            roomId=data.get("room_id"),  # room_id → roomId 변환
+            roomNumber=data.get("room_number"),  # room_number → rooomNumber 변환
         )
 
 

--- a/src/handlers/students_handler.py
+++ b/src/handlers/students_handler.py
@@ -26,19 +26,27 @@ def get_all(event, context):
 
 def get_by_room(event, context):
     """
-    GET /students/{roomId} API 요청을 처리하는 핸들러 (특정 방 학생 조회)
+    GET /students/{roomNumber} API 요청을 처리하는 핸들러 (특정 방 학생 조회)
     """
     logger.info("✅ Processing get_by_room students request")
 
-    # URL 경로에서 roomId 값을 추출
+    # URL 경로에서 roomNumber 값을 추출
     path_params = event.get("pathParameters") or {}
-    room_id = path_params.get("roomId")
+    room_number = path_params.get("roomNumber")
 
-    if not room_id:
-        return responses.create_error_response("Room ID is required.", 400)
+    if not room_number:
+        return responses.create_error_response("Room Number is required.", 400)
 
-    # '실무자'에게 room_id를 포함하여 업무 지시
-    students_data, error = students_service.get_students(room_id=room_id)
+    # 문자열을 정수로 변환 (DB에서 room_number는 int 타입)
+    try:
+        room_number_int = int(room_number)
+    except ValueError:
+        return responses.create_error_response(
+            "Room Number must be a valid integer.", 400
+        )
+
+    # '실무자'에게 room_number를 포함하여 업무 지시
+    students_data, error = students_service.get_students(room_number=room_number_int)
 
     if error:
         return responses.create_error_response(error, 500)

--- a/src/services/students_service.py
+++ b/src/services/students_service.py
@@ -6,10 +6,10 @@ logger = logging.getLogger()
 logger.setLevel(logging.INFO)
 
 
-def get_students(room_id: str | None = None):
+def get_students(room_number: int | None = None):
     """
     Supabase 클라이언트를 사용하여 학생 정보를 조회합니다.
-    room_id가 주어지면 해당 방의 학생만 필터링합니다.
+    room_number가 주어지면 해당 방의 학생만 필터링합니다.
     """
     try:
         supabase = get_supabase_client("core")
@@ -18,13 +18,13 @@ def get_students(room_id: str | None = None):
 
         logger.info("Supabase 'students' 테이블 조회 시작")
 
-        # room_id가 있으면 필터링, 없으면 전체 조회
-        if room_id:
+        # room_number가 있으면 필터링, 없으면 전체 조회
+        if room_number:
             response = (
                 supabase.postgrest.schema("core")
                 .from_("students")
-                .select("room_id, name, studentNo")
-                .eq("room_id", room_id)
+                .select("id, name, studentNo, affiliation, major, room_number")
+                .eq("room_number", room_number)
                 .order("name")
                 .execute()
             )
@@ -32,7 +32,7 @@ def get_students(room_id: str | None = None):
             response = (
                 supabase.postgrest.schema("core")
                 .from_("students")
-                .select("id, name, studentNo, affiliation, major, room_id")
+                .select("id, name, studentNo, affiliation, major, room_number")
                 .order("name")
                 .execute()
             )


### PR DESCRIPTION
###  변경사항
- `GET /students/{roomNumber}` API의 path parameter 식 수정
- `room_id` 가 아닌 `room_number`를 Primary_Key 로 사용
- URL 경로 파라미터에서 받은 문자열을 정수로 변환하는 로직 추가

### 수정된 파일
- `src/handlers/students_handler.py`
  - `get_by_room` 함수에서 `roomNumber` **파라미터 타입 변환 (문자열 -> 정수) 로직** 추가
  

프론트엔드 요청에 따라 테이블 `rooms`에서 `id`가 아닌 **`room_number`**(101, 102...)를 사용해서 학생을 GET 하는 것으로 수정