### PR TITLE
fix: GET /students API 경로 충돌 해결 및 roomNumber 파라미터 통합

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -7,7 +7,6 @@ on:
     branches:
       - dev
       - prod
-      - feat/swagger-ui
 
 # 실행될 작업(Job)들의 목록
 jobs:

--- a/docs/openapi.yml
+++ b/docs/openapi.yml
@@ -45,9 +45,18 @@ paths:
   /students:
     get:
       summary: 학생 목록 조회
-      description: 전체 학생 목록을 조회합니다.
+      description: 전체 또는 특정 호실의 학생 목록을 조회합니다.
       tags:
         - Students
+      parameters:
+        - name: roomNumber
+          in: query
+          description: 호실 번호 (기본값 101, 없으면 전체 조회)
+          required: false
+          schema:
+            type: integer
+            minimum: 1
+          example: 101
       responses:
         "200":
           description: 성공적으로 학생 목록을 반환했습니다.
@@ -57,38 +66,8 @@ paths:
                 type: array
                 items:
                   $ref: "#/components/schemas/Student"
-        "500":
-          description: 서버 내부 오류
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/Error"
-
-  /students/{roomId}:
-    get:
-      summary: 특정 호실 학생 목록 조회
-      description: 특정 호실에 거주하는 학생들의 목록을 조회합니다.
-      tags:
-        - Students
-      parameters:
-        - name: roomId
-          in: path
-          description: 조회할 호실의 ID
-          required: true
-          schema:
-            type: integer
-          example: 1
-      responses:
-        "200":
-          description: 성공적으로 해당 호실의 학생 목록을 반환했습니다.
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  $ref: "#/components/schemas/Student"
         "400":
-          description: 잘못된 요청 (잘못된 roomId 형식)
+          description: 잘못된 요청 (잘못된 roomNumber 형식)
           content:
             application/json:
               schema:
@@ -353,10 +332,10 @@ components:
           type: string
           description: 전공
           example: "컴퓨터공학부"
-        roomId:
-          type: string
+        roomNumber:
+          type: integer
           description: 호실 ID
-          example: "101"
+          example: 101
 
     Notice:
       type: object

--- a/serverless.yml
+++ b/serverless.yml
@@ -92,23 +92,13 @@ functions:
 
   getStudents:
     name: ${self:provider.stage}-api-getStudents
-    handler: src.handlers.students_handler.get_all
+    handler: src.handlers.students_handler.get_students
     layers:
       - { Ref: AppDependenciesLambdaLayer }
     events:
       - httpApi:
           method: get
           path: /students
-
-  getStudentsByRoom:
-    name: ${self:provider.stage}-api-getStudentsByRoom
-    handler: src.handlers.students_handler.get_by_room
-    layers:
-      - { Ref: AppDependenciesLambdaLayer }
-    events:
-      - httpApi:
-          method: get
-          path: /students/{roomNumber}
 
   createNotice:
     name: ${self:provider.stage}-api-createNotice

--- a/src/handlers/students_handler.py
+++ b/src/handlers/students_handler.py
@@ -8,49 +8,32 @@ logger = logging.getLogger()
 logger.setLevel(logging.INFO)
 
 
-def get_all(event, context):
+def get_students(event, context):
     """
-    GET /students API 요청을 처리하는 핸들러 (모든 학생 조회)
+    GET /students API 요청을 처리하는 핸들러
+    - 쿼리 파라미터 없음: 전체 학생 조회
+    - roomNumber 쿼리 파라미터 있음: 해당 방 학생 조회
     """
-    logger.info("✅ Processing get_all students request")
-    # '실무자'에게 room_id 없이 업무 지시
-    students_data, error = students_service.get_students()
+    logger.info("✅ Processing get students request")
+
+    query_params = event.get("queryStringParameters") or {}
+    room_number = query_params.get("roomNumber")
+
+    if room_number:
+        # 특정 방 학생 조회
+        try:
+            room_number_int = int(room_number)
+        except ValueError:
+            return responses.create_error_response("Invalid room number format.", 400)
+
+        result, error = students_service.get_students(room_number_int)
+    else:
+        # 전체 학생 조회
+        result, error = students_service.get_students()
 
     if error:
         return responses.create_error_response(error, 500)
 
     # DTO를 사용하여 응답 데이터 변환
-    student_list_dto = StudentListDTO.from_supabase_data(students_data)
-    return responses.create_success_response(student_list_dto.to_dict())
-
-
-def get_by_room(event, context):
-    """
-    GET /students/{roomNumber} API 요청을 처리하는 핸들러 (특정 방 학생 조회)
-    """
-    logger.info("✅ Processing get_by_room students request")
-
-    # URL 경로에서 roomNumber 값을 추출
-    path_params = event.get("pathParameters") or {}
-    room_number = path_params.get("roomNumber")
-
-    if not room_number:
-        return responses.create_error_response("Room Number is required.", 400)
-
-    # 문자열을 정수로 변환 (DB에서 room_number는 int 타입)
-    try:
-        room_number_int = int(room_number)
-    except ValueError:
-        return responses.create_error_response(
-            "Room Number must be a valid integer.", 400
-        )
-
-    # '실무자'에게 room_number를 포함하여 업무 지시
-    students_data, error = students_service.get_students(room_number=room_number_int)
-
-    if error:
-        return responses.create_error_response(error, 500)
-
-    # DTO를 사용하여 응답 데이터 변환
-    student_list_dto = StudentListDTO.from_supabase_data(students_data)
+    student_list_dto = StudentListDTO.from_supabase_data(result)
     return responses.create_success_response(student_list_dto.to_dict())


### PR DESCRIPTION
### 🔧 변경사항
- **API 경로 충돌 해결**: `GET /students`와 `GET /students/{roomNumber}` 경로 충돌 문제 해결
- **단일 엔드포인트 통합**: 하나의 `/students` 경로에서 쿼리 파라미터로 전체/방별 조회 구분
- **OpenAPI 스펙 업데이트**: 새로운 API 구조에 맞게 문서화 수정

### 📁 수정된 파일
- `serverless.yml`
  - `getStudentsByRoom` 함수 제거 (경로 충돌 해결)
  - `getStudents` 함수만 유지하여 단일 엔드포인트로 통합

- `src/handlers/students_handler.py`
  - `get_all` 함수에서 쿼리 파라미터 `roomNumber` 처리 로직 추가
  - 전체 조회와 방별 조회를 하나의 함수에서 처리

- `docs/openapi.yml`
  - `/students` API 스펙 업데이트
  - `roomNumber` 쿼리 파라미터 추가
  - Student 스키마에서 `roomId` → `roomNumber`로 수정
  - 400 에러 응답 추가

### 📖 새로운 API 사용법
```
# 전체 학생 조회
GET /students

# 특정 호실 학생 조회  
GET /students?roomNumber=101
```