### PR TITLE
feat: FCM HTTP v1 기반 알림 서비스 API 및 배포 파이프라인 통합

### DIFF
--- a/.cursor/rules/push_api.mdc
+++ b/.cursor/rules/push_api.mdc
@@ -1,0 +1,319 @@
+# PWA 알림 서비스 API 설계 문서
+
+## 개요
+
+PWA(Progressive Web App) 방식의 웹 앱을 위한 Firebase Cloud Messaging(FCM) 기반 알림 서비스입니다. 새로운 공지사항이 등록될 때 구독 허용한 모든 학생에게 푸시 알림을 발송합니다.
+
+## 데이터베이스 구조
+
+기존 `notify` 스키마의 테이블을 활용합니다:
+
+- **`notify.subscriptions`**: FCM 구독 관리
+
+  - `id`, `fcm_token`, `student_no`, `is_active`, `platform`, `created_at`, `updated_at`
+  - `core.students.studentNo` 참조
+
+- **`notify.notice_logs`**: 발송 결과 로깅
+  - `id`, `notice_id`, `subscription_id`, `status`, `error_message`, `sent_at`
+  - `core.notice.id`, `notify.subscriptions.id` 참조
+
+## API 엔드포인트
+
+### 1. 구독 관리 API
+
+#### POST /subscriptions
+
+FCM 구독을 등록하거나 업데이트합니다.
+
+**Request Body:**
+
+```json
+{
+  "fcm_token": "string",
+  "student_no": "string",
+  "platform": "web"
+}
+```
+
+**Response:**
+
+```json
+{
+  "success": true,
+  "data": {
+    "subscription_id": 123,
+    "fcm_token": "string",
+    "student_no": "string",
+    "platform": "web",
+    "is_active": true,
+    "created_at": "2024-01-15T10:30:00Z"
+  }
+}
+```
+
+#### GET /subscriptions/status
+
+구독 상태를 조회합니다.
+
+**Query Parameters:**
+
+- `fcm_token`: FCM 토큰
+
+**Response:**
+
+```json
+{
+  "success": true,
+  "data": {
+    "active": true,
+    "subscription_id": 123,
+    "student_no": "string",
+    "platform": "web",
+    "created_at": "2024-01-15T10:30:00Z"
+  }
+}
+```
+
+### 2. 알림 발송 API (내부)
+
+#### POST /internal/notifications/send
+
+새 공지사항 알림을 발송합니다. (Supabase 웹훅 트리거)
+
+**Headers:**
+
+- `X-Webhook-Secret`: 웹훅 검증용 시크릿
+
+**Request Body:**
+
+```json
+{
+  "record": {
+    "id": 123
+  }
+}
+```
+
+**Response:**
+
+```json
+{
+  "success": true,
+  "data": {
+    "sent_count": 150,
+    "failed_count": 5,
+    "invalid_count": 2,
+    "total_subscriptions": 157
+  }
+}
+```
+
+## Firebase 설정
+
+### 환경변수
+
+- `FCM_PROJECT_ID`: Firebase 프로젝트 ID
+- `FCM_SERVICE_ACCOUNT_JSON`: Firebase 서비스 계정 JSON (HTTP v1 API 사용)
+- `WEBHOOK_SECRET`: 내부 API 보호용 시크릿
+
+### FCM 메시지 포맷 (HTTP v1 API)
+
+```json
+{
+  "message": {
+    "token": "FCM_TOKEN",
+    "notification": {
+      "title": "새 공지사항",
+      "body": "공지 제목 (최대 100자)"
+    },
+    "data": {
+      "notice_id": "123",
+      "type": "notice",
+      "url": "/notice/123"
+    },
+    "webpush": {
+      "fcm_options": {
+        "link": "https://yourdomain.com/notice/123"
+      }
+    }
+  }
+}
+```
+
+### FCM 멀티캐스트 메시지 포맷
+
+```json
+{
+  "message": {
+    "tokens": ["FCM_TOKEN_1", "FCM_TOKEN_2", "FCM_TOKEN_3"],
+    "notification": {
+      "title": "새 공지사항",
+      "body": "공지 제목 (최대 100자)"
+    },
+    "data": {
+      "notice_id": "123",
+      "type": "notice",
+      "url": "/notice/123"
+    },
+    "webpush": {
+      "fcm_options": {
+        "link": "https://yourdomain.com/notice/123"
+      }
+    }
+  }
+}
+```
+
+### PWA 자동 토큰 갱신
+
+- **프론트엔드 역할**: PWA에서 FCM 토큰 변경 시 `POST /subscriptions` API 호출
+- **백엔드 역할**: 동일한 `fcm_token`으로 재등록 시 UPSERT 처리하여 자동 갱신
+- **장점**: 사용자 개입 없이 토큰이 자동으로 최신 상태 유지
+
+## 핵심 기능
+
+### 1. 구독 관리
+
+- **등록/업데이트**: FCM 토큰 기반으로 UPSERT 처리
+- **중복 방지**: `fcm_token` UNIQUE 제약 활용
+- **플랫폼 구분**: web, android, ios 지원
+
+### 2. 알림 발송
+
+- **트리거**: `core.notice` 테이블 INSERT 시 Supabase 웹훅
+- **대상**: `is_active=true`인 모든 구독자
+- **멀티캐스트**: FCM HTTP v1 API로 배치 발송
+- **결과 로깅**: 개별 발송 결과를 `notice_logs`에 기록
+
+### 3. 무효 토큰 처리 (자동화)
+
+- **자동 감지**: FCM HTTP v1 API 응답에서 에러 코드 기반 감지
+- **자동 비활성화**: 무효 토큰은 `is_active=false`로 설정
+- **자동 갱신**: PWA에서 토큰 변경 시 자동 재등록
+- **로그 분류**: `success`, `failed`, `invalid_token` 상태 구분
+
+### 4. 에러 처리
+
+- **웹훅 검증**: `X-Webhook-Secret` 헤더 확인
+- **OAuth 2.0 인증**: 서비스 계정 JSON으로 액세스 토큰 발급
+- **토큰 검증**: FCM 토큰 유효성 검사
+- **재시도 로직**: 일시적 실패에 대한 재시도 (선택사항)
+
+## 파일 구조
+
+```
+src/
+├── handlers/
+│   ├── notifications_handler.py    # 알림 발송 핸들러
+│   └── subscriptions_handler.py    # 구독 관리 핸들러
+├── services/
+│   ├── notifications_service.py    # 알림 발송 서비스
+│   └── subscriptions_service.py    # 구독 관리 서비스
+├── dto/
+│   └── notification_dto.py         # 알림 관련 DTO
+└── utils/
+    └── fcm_client.py              # FCM 클라이언트 (HTTP v1 API)
+```
+
+## 보안 고려사항
+
+### 1. 웹훅 보호
+
+- 내부 API는 `X-Webhook-Secret` 헤더로 보호
+- Supabase 웹훅 설정 시 시크릿 키 설정
+
+### 2. 토큰 관리
+
+- FCM 토큰은 민감 정보로 취급
+- 서비스 계정 JSON은 환경변수로 안전하게 관리
+- 로그에 전체 토큰 저장 금지 (마스킹 처리)
+
+### 3. 접근 제어
+
+- 구독 API는 공개 (PWA에서 호출)
+- 알림 발송 API는 내부 전용
+
+## 모니터링
+
+### 1. 메트릭
+
+- 발송 성공/실패/무효 건수
+- 활성 구독자 수
+- 평균 응답 시간
+
+### 2. 로그
+
+- CloudWatch를 통한 구조화된 로깅
+- 에러 상황별 상세 로그
+
+## 테스트 시나리오
+
+### 1. 구독 등록 테스트
+
+1. PWA에서 FCM 토큰 획득
+2. `POST /subscriptions`로 구독 등록
+3. `GET /subscriptions/status`로 상태 확인
+
+### 2. 알림 발송 테스트
+
+1. `POST /notice`로 공지사항 생성
+2. Supabase 웹훅 트리거 또는 `POST /internal/notifications/send` 직접 호출
+3. 응답에서 발송 결과 확인
+4. PWA에서 알림 수신 확인
+
+### 3. 무효 토큰 테스트
+
+1. 만료된 FCM 토큰으로 구독 등록
+2. 알림 발송 시 `invalid_token` 처리 확인
+3. 구독 상태가 `is_active=false`로 변경되는지 확인
+
+## 배포 구성
+
+### serverless.yml 추가 함수
+
+```yaml
+functions:
+  # 구독 관리
+  createSubscription:
+    handler: src.handlers.subscriptions_handler.create
+    events:
+      - httpApi:
+          method: post
+          path: /subscriptions
+
+  getSubscriptionStatus:
+    handler: src.handlers.subscriptions_handler.get_status
+    events:
+      - httpApi:
+          method: get
+          path: /subscriptions/status
+
+  # 알림 발송 (내부)
+  sendNotification:
+    handler: src.handlers.notifications_handler.send_push
+    events:
+      - httpApi:
+          method: post
+          path: /internal/notifications/send
+    environment:
+      FCM_PROJECT_ID: ${file(envs/config.${self:provider.stage}.json):FCM_PROJECT_ID}
+      FCM_SERVICE_ACCOUNT_JSON: ${file(envs/config.${self:provider.stage}.json):FCM_SERVICE_ACCOUNT_JSON}
+      WEBHOOK_SECRET: ${file(envs/config.${self:provider.stage}.json):WEBHOOK_SECRET}
+```
+
+## 개발 순서
+
+1. **DTO 정의**: `notification_dto.py` 작성
+2. **FCM 클라이언트**: HTTP v1 API 기반 `fcm_client.py` 작성
+3. **서비스 레이어**: 구독/알림 서비스 구현
+4. **핸들러 레이어**: API 엔드포인트 구현
+5. **serverless.yml**: 함수 정의 및 환경변수 설정
+6. **테스트**: Postman을 통한 API 테스트
+7. **웹훅 연동**: Supabase 웹훅 설정
+
+## 주의사항
+
+- FCM HTTP v1 API 사용 (Legacy API는 2024년 6월 지원 중단)
+- OAuth 2.0 인증을 위한 서비스 계정 JSON 필요
+- PWA에서 FCM 토큰은 앱 재설치/업데이트 시 변경될 수 있으므로 자동 갱신 필요
+- 대량 발송 시 FCM 할당량 제한 고려 필요

--- a/.cursor/rules/push_todo.mdc
+++ b/.cursor/rules/push_todo.mdc
@@ -1,0 +1,223 @@
+## Rule Name: push_todo
+
+### Description:
+
+- PWA 알림 서비스 API 개발을 위한 단계별 투두리스트
+- Firebase Cloud Messaging(FCM) 기반 푸시 알림 시스템 구축
+- 기존 DB 스키마 활용: notify.subscriptions, notify.notice_logs
+- 공지사항 등록 시 모든 활성 구독자에게 자동 알림 발송
+
+### 📋 TODO List
+
+#### 1. DTO 정의 (src/dto/notification_dto.py)
+
+- [x] **SubscriptionDTO 클래스 추가**
+
+  - 필드: id:int, fcm_token:str, student_no:str, is_active:bool, platform:str, created_at:str, updated_at:str
+  - from_supabase_data() 정적 메서드
+  - Supabase 응답 데이터를 DTO로 변환
+
+- [x] **SubscriptionCreateRequestDTO 클래스 추가**
+
+  - 필드: fcm_token:str, student_no:str, platform:str
+  - validate() 메서드로 데이터 검증
+  - 요청 데이터 검증용 DTO
+
+- [x] **NotificationLogDTO 클래스 추가**
+
+  - 필드: id:int, notice_id:int, subscription_id:int, status:str, error_message:str|None, sent_at:str
+  - from_supabase_data() 정적 메서드
+  - 발송 결과 로깅용 DTO
+
+- [x] **DTO 패키지 등록 (src/dto/**init**.py)**
+  - import 추가: SubscriptionDTO, SubscriptionCreateRequestDTO, NotificationLogDTO
+  - **all** 리스트에 추가
+
+#### 2. FCM 클라이언트 (src/utils/fcm_client.py)
+
+- [x] **HTTP v1 API 기반 FCM 클라이언트 구현**
+
+  - FCM HTTP v1 API 사용 (OAuth 2.0 + 서비스 계정 JSON)
+  - send_notification() 함수: 단일 토큰 발송
+  - send_multicast_notification() 함수: 다중 토큰 발송
+  - 무효 토큰 자동 감지 및 분류
+
+- [x] **OAuth 2.0 인증 구현**
+
+  - 서비스 계정 JSON으로 액세스 토큰 발급
+  - 토큰 갱신 로직 (만료 시 자동 재발급)
+  - Google OAuth 2.0 API 호출
+
+- [x] **무효 토큰 감지 로직**
+
+  - HTTP v1 API 응답 에러 코드 기반 감지
+  - INVALID_ARGUMENT, UNREGISTERED, SENDER_ID_MISMATCH 등
+  - 반환값: (success_count, failure_count, failed_tokens, invalid_tokens)
+
+- [x] **에러 처리 및 로깅**
+  - FCM HTTP v1 API 에러 분류 및 로깅
+  - OAuth 2.0 인증 에러 처리
+  - 재시도 로직 (선택사항)
+  - 할당량 초과 처리
+
+#### 3. 구독 관리 서비스 (src/services/subscriptions_service.py)
+
+- [x] **create_subscription(request_dto) 함수 추가**
+
+  - FCM 구독 생성/업데이트 (UPSERT)
+  - fcm_token UNIQUE 제약 활용
+  - SubscriptionDTO 반환
+
+- [x] **get_subscription_status(fcm_token) 함수 추가**
+
+  - FCM 토큰으로 구독 상태 조회
+  - active, subscription_id, student_no, platform 정보 반환
+
+- [x] **deactivate_invalid_subscription(subscription_id) 함수 추가**
+  - 무효 토큰 구독 비활성화
+  - is_active = false로 업데이트
+
+#### 4. 알림 발송 서비스 (src/services/notifications_service.py)
+
+- [x] **get_active_subscriptions() 함수 추가**
+
+  - is_active=true인 모든 구독자 조회
+  - SubscriptionDTO 리스트 반환
+
+- [x] **log_notification_result() 함수 추가**
+
+  - 발송 결과 로깅 (UPSERT)
+  - notice_logs 테이블에 성공/실패/무효 상태 기록
+
+- [x] **deactivate_invalid_subscription() 함수 추가**
+  - 무효 토큰 구독 비활성화 호출
+
+#### 5. 구독 관리 핸들러 (src/handlers/subscriptions_handler.py)
+
+- [x] **create_subscription_handler(event, context) 함수 추가**
+
+  - POST /subscriptions 엔드포인트
+  - body 파싱: fcm_token, student_no, platform
+  - create_subscription() 서비스 호출
+  - create_success_response()로 응답
+
+- [x] **get_subscription_status_handler(event, context) 함수 추가**
+  - GET /subscriptions/status 엔드포인트
+  - 쿼리 파라미터: fcm_token
+  - get_subscription_status() 서비스 호출
+  - create_success_response()로 응답
+
+#### 6. 알림 발송 핸들러 (src/handlers/notifications_handler.py)
+
+- [x] **send_push_notification(event, context) 함수 추가**
+
+  - POST /internal/notifications/send 엔드포인트
+  - 웹훅 검증 (X-Webhook-Secret)
+  - 공지사항 정보 조회
+  - 활성 구독자 조회 및 FCM 발송
+  - 무효 토큰 자동 비활성화
+  - 발송 결과 로깅
+
+- [x] **웹훅 검증 로직**
+  - X-Webhook-Secret 헤더 검증
+  - 환경변수 WEBHOOK_SECRET과 비교
+
+#### 7. 서버리스 설정 (serverless.yml)
+
+- [x] **createSubscription 함수 추가**
+
+  - handler: src.handlers.subscriptions_handler.create_subscription_handler
+  - events: httpApi { path: /subscriptions, method: post }
+  - layers: AppDependencies
+
+- [x] **getSubscriptionStatus 함수 추가**
+
+  - handler: src.handlers.subscriptions_handler.get_subscription_status_handler
+  - events: httpApi { path: /subscriptions/status, method: get }
+  - layers: AppDependencies
+
+- [x] **sendNotification 함수 추가**
+  - handler: src.handlers.notifications_handler.send_push_notification
+  - events: httpApi { path: /internal/notifications/send, method: post }
+  - layers: AppDependencies
+  - environment: FCM_PROJECT_ID, FCM_SERVICE_ACCOUNT_JSON, WEBHOOK_SECRET
+
+#### 8. 환경변수 설정 (envs/config.dev.json)
+
+- [x] **FCM 관련 환경변수 추가**
+  - FCM_PROJECT_ID: Firebase 프로젝트 ID
+  - FCM_SERVICE_ACCOUNT_JSON: Firebase 서비스 계정 JSON (HTTP v1 API)
+  - WEBHOOK_SECRET: 웹훅 검증용 시크릿
+
+#### 9. 의존성 추가 (requirements.txt)
+
+- [x] **Firebase 관련 패키지 추가**
+  - requests: HTTP v1 API 호출용
+  - google-auth: OAuth 2.0 인증용
+  - google-auth-oauthlib: OAuth 2.0 라이브러리
+
+#### 10. OpenAPI 문서 (docs/openapi.yml)
+
+- [x] **SubscriptionCreateRequest 스키마 추가**
+
+  - fcm_token: string (required)
+  - student_no: string (required)
+  - platform: string (required, enum: [web, android, ios])
+
+- [x] **SubscriptionStatus 스키마 추가**
+
+  - active: boolean
+  - subscription_id: integer
+  - student_no: string
+  - platform: string
+  - created_at: string
+
+- [x] **NotificationSendResponse 스키마 추가**
+
+  - sent_count: integer
+  - failed_count: integer
+  - invalid_count: integer
+  - total_subscriptions: integer
+
+- [x] **API 경로 추가**
+  - POST /subscriptions
+  - GET /subscriptions/status
+  - POST /internal/notifications/send
+
+#### 11. 테스트 및 검증
+
+- [x] **구독 관리 API 테스트**
+
+  - POST /subscriptions (구독 등록)
+  - GET /subscriptions/status (구독 상태 조회)
+
+- [x] **알림 발송 API 테스트**
+
+  - POST /internal/notifications/send (알림 발송)
+  - 웹훅 시크릿 검증 테스트
+
+- [x] **무효 토큰 처리 테스트**
+
+  - 만료된 토큰으로 구독 등록
+  - 알림 발송 시 자동 비활성화 확인
+
+- [x] **에러 케이스 테스트**
+  - 400: 필수 필드 누락, 잘못된 데이터 형식
+  - 401: 웹훅 시크릿 불일치
+  - 500: FCM API 에러, DB 연결 실패
+
+### 🎯 우선순위
+
+1. **High Priority**: DTO 정의 → FCM 클라이언트 → 서비스 레이어
+2. **Medium Priority**: 핸들러 레이어 → 서버리스 설정 → 환경변수
+3. **Low Priority**: OpenAPI 문서 → 테스트 및 검증
+
+### 📝 참고사항
+
+- 기존 DB 스키마 활용 (notify.subscriptions, notify.notice_logs)
+- FCM HTTP v1 API 사용 (OAuth 2.0 + 서비스 계정 JSON)
+- 무효 토큰 자동 감지 및 비활성화
+- OAuth 2.0 액세스 토큰 자동 갱신
+- 모든 서비스 함수는 (data, error) 튜플 반환 패턴 준수
+- 핸들러는 얇게, 서비스에서 로직/에러 로깅 상세히
+- 웹훅 보안을 위한 시크릿 검증 필수

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -61,14 +61,14 @@ jobs:
         if: env.STAGE == 'dev'
         run: |
           mkdir -p envs
-          echo '{ "SUPABASE_URL": "${{ secrets.SUPABASE_URL }}", "SUPABASE_API_KEY": "${{ secrets.SUPABASE_API_KEY }}", "API_GATEWAY_ID": "${{ secrets.API_GATEWAY_ID }}", "BILL_BUCKET_NAME": "${{ secrets.BILL_BUCKET_NAME }}" }' > envs/config.dev.json
+          echo '{ "SUPABASE_URL": "${{ secrets.SUPABASE_URL }}", "SUPABASE_API_KEY": "${{ secrets.SUPABASE_API_KEY }}", "API_GATEWAY_ID": "${{ secrets.API_GATEWAY_ID }}", "BILL_BUCKET_NAME": "${{ secrets.BILL_BUCKET_NAME }}", "FCM_SERVICE_ACCOUNT_PATH": "envs/firebase-service-account.json", "FCM_PROJECT_ID": "${{ secrets.FCM_PROJECT_ID }}", "WEBHOOK_SECRET": "${{ secrets.WEBHOOK_SECRET }}" }' > envs/config.dev.json
 
       # 6-2. prod 환경 설정 파일 생성 (이후 실제 PROD DB 연결이 필요함)
       - name: Create PROD environment file
         if: env.STAGE == 'prod'
         run: |
           mkdir -p envs
-          echo '{ "SUPABASE_URL": "${{ secrets.PROD_SUPABASE_URL }}", "SUPABASE_API_KEY": "${{ secrets.PROD_SUPABASE_API_KEY }}", "API_GATEWAY_ID": "${{ secrets.PROD_API_GATEWAY_ID }}", "BILL_BUCKET_NAME": "${{ secrets.PROD_BILL_BUCKET_NAME }}" }' > envs/config.prod.json
+          echo '{ "SUPABASE_URL": "${{ secrets.PROD_SUPABASE_URL }}", "SUPABASE_API_KEY": "${{ secrets.PROD_SUPABASE_API_KEY }}", "API_GATEWAY_ID": "${{ secrets.PROD_API_GATEWAY_ID }}", "BILL_BUCKET_NAME": "${{ secrets.PROD_BILL_BUCKET_NAME }}", "FCM_SERVICE_ACCOUNT_PATH": "envs/firebase-service-account.json", "FCM_PROJECT_ID": "${{ secrets.PROD_FCM_PROJECT_ID }}", "WEBHOOK_SECRET": "${{ secrets.PROD_WEBHOOK_SECRET }}" }' > envs/config.prod.json
 
       # 7. Python Lambda Layer 빌드
       # 우리가 찾은, Docker 없이 Linux 호환 라이브러리를 설치하는 명령어 실행
@@ -86,6 +86,10 @@ jobs:
           # 빌드 검증
           ls -la layer/python/ | head -5
 
-      # 8. Serverless Framework v4를 사용하여 AWS에 배포
+      # 8. Firebase Service Account JSON 파일 생성 (base64 디코딩)
+      - name: Create Firebase Service Account JSON
+        run: echo "${{ secrets.FIREBASE_SERVICE_ACCOUNT_JSON }}" | base64 --decode > envs/firebase-service-account.json
+
+      # 9. Serverless Framework v4를 사용하여 AWS에 배포
       - name: Deploy to AWS (${{ env.STAGE }})
         run: sls deploy --stage ${{ env.STAGE }}

--- a/docs/openapi.yml
+++ b/docs/openapi.yml
@@ -599,7 +599,165 @@ paths:
               schema:
                 $ref: "#/components/schemas/Error"
 
+  /subscriptions:
+    post:
+      summary: FCM 구독 생성
+      description: FCM 토큰을 등록하여 푸시 알림을 받을 수 있도록 구독합니다.
+      tags:
+        - Notifications
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/SubscriptionCreateRequest"
+            example:
+              fcm_token: "fcm_token_example_12345"
+              student_no: "20243105"
+              platform: "ios"
+      responses:
+        "200":
+          description: 구독이 성공적으로 생성되었습니다.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Subscription"
+        "400":
+          description: 잘못된 요청 (필수 필드 누락 또는 형식 오류)
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "500":
+          description: 서버 내부 오류
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+
+  /subscriptions/status:
+    get:
+      summary: FCM 구독 상태 조회
+      description: FCM 토큰을 통해 현재 구독 상태를 조회합니다.
+      tags:
+        - Notifications
+      parameters:
+        - name: fcm_token
+          in: query
+          description: 조회할 FCM 토큰
+          required: true
+          schema:
+            type: string
+          example: "fcm_token_example_12345"
+      responses:
+        "200":
+          description: 구독 상태를 성공적으로 반환했습니다.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SubscriptionStatus"
+        "400":
+          description: 잘못된 요청 (fcm_token 파라미터 누락)
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "404":
+          description: 구독을 찾을 수 없음
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "500":
+          description: 서버 내부 오류
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+
+  /notifications:
+    post:
+      summary: 수동 알림 발송
+      description: 관리자가 수동으로 모든 구독자에게 알림을 발송합니다.
+      tags:
+        - Notifications
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/NotificationSendRequest"
+            example:
+              title: "긴급 공지"
+              content: "제2정릉생활관 정보자원관리원 화재 안내"
+              notice_id: 123
+      responses:
+        "200":
+          description: 알림이 성공적으로 발송되었습니다.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/NotificationResult"
+        "400":
+          description: 잘못된 요청 (필수 필드 누락)
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "500":
+          description: 서버 내부 오류
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+
+  /webhook/notify:
+    post:
+      summary: Supabase 웹훅 (내부용)
+      description: Supabase에서 새 공지사항이 생성될 때 자동으로 호출되는 웹훅입니다.
+      tags:
+        - Notifications
+      security:
+        - WebhookSecret: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/WebhookPayload"
+      responses:
+        "200":
+          description: 웹훅이 성공적으로 처리되었습니다.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/NotificationResult"
+        "401":
+          description: 인증 실패 (잘못된 웹훅 시크릿)
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "400":
+          description: 잘못된 요청
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "500":
+          description: 서버 내부 오류
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+
 components:
+  securitySchemes:
+    WebhookSecret:
+      type: apiKey
+      in: header
+      name: X-Webhook-Secret
+      description: 웹훅 인증을 위한 시크릿 키
   schemas:
     Room:
       type: object
@@ -843,6 +1001,172 @@ components:
           description: 에러 메시지
           example: "Invalid request parameters"
 
+    Subscription:
+      type: object
+      description: FCM 구독 정보
+      properties:
+        id:
+          type: integer
+          description: 구독 ID
+          example: 1
+        fcm_token:
+          type: string
+          description: FCM 토큰
+          example: "fcm_token_example_12345"
+        student_no:
+          type: string
+          description: 학번
+          example: "20243105"
+        is_active:
+          type: boolean
+          description: 활성화 상태
+          example: true
+        platform:
+          type: string
+          description: 플랫폼
+          example: "ios"
+        created_at:
+          type: string
+          format: date-time
+          description: 생성일시
+          example: "2024-09-01T10:00:00Z"
+        updated_at:
+          type: string
+          format: date-time
+          description: 수정일시
+          example: "2024-09-01T10:00:00Z"
+
+    SubscriptionCreateRequest:
+      type: object
+      description: FCM 구독 생성 요청
+      required:
+        - fcm_token
+        - student_no
+      properties:
+        fcm_token:
+          type: string
+          description: FCM 토큰
+          example: "fcm_token_example_12345"
+        student_no:
+          type: string
+          description: 학번
+          example: "20192762"
+        platform:
+          type: string
+          description: 플랫폼 (기본값 web)
+          default: "web"
+          example: "web"
+
+    SubscriptionStatus:
+      type: object
+      description: FCM 구독 상태
+      properties:
+        active:
+          type: boolean
+          description: 활성화 상태
+          example: true
+        subscription_id:
+          type: integer
+          description: 구독 ID
+          example: 1
+        student_no:
+          type: string
+          description: 학번
+          example: "20243105"
+        platform:
+          type: string
+          description: 플랫폼
+          example: "ios"
+        created_at:
+          type: string
+          format: date-time
+          description: 생성일시
+          example: "2024-09-01T10:00:00Z"
+        updated_at:
+          type: string
+          format: date-time
+          description: 수정일시
+          example: "2024-09-01T10:00:00Z"
+
+    NotificationSendRequest:
+      type: object
+      description: 수동 알림 발송 요청
+      required:
+        - title
+        - content
+        - notice_id
+      properties:
+        title:
+          type: string
+          description: 알림 제목
+          example: "긴급 공지"
+        content:
+          type: string
+          description: 알림 내용
+          example: "내일 시험 일정이 변경되었습니다."
+        notice_id:
+          type: integer
+          description: 공지사항 ID
+          example: 123
+
+    NotificationResult:
+      type: object
+      description: 알림 발송 결과
+      properties:
+        success:
+          type: boolean
+          description: 발송 성공 여부
+          example: true
+        total_subscriptions:
+          type: integer
+          description: 전체 구독자 수
+          example: 150
+        success_count:
+          type: integer
+          description: 성공한 발송 수
+          example: 145
+        failure_count:
+          type: integer
+          description: 실패한 발송 수
+          example: 5
+        invalid_tokens:
+          type: array
+          items:
+            type: string
+          description: 무효한 토큰 리스트
+          example: ["token1", "token2"]
+        failed_tokens:
+          type: array
+          items:
+            type: string
+          description: 실패한 토큰 리스트
+          example: ["token3"]
+
+    WebhookPayload:
+      type: object
+      description: Supabase 웹훅 페이로드
+      properties:
+        type:
+          type: string
+          description: 이벤트 타입
+          example: "INSERT"
+        record:
+          type: object
+          description: 공지사항 데이터
+          properties:
+            id:
+              type: integer
+              description: 공지사항 ID
+              example: 123
+            title:
+              type: string
+              description: 제목
+              example: "새 공지사항"
+            content:
+              type: string
+              description: 내용
+              example: "공지사항 내용입니다."
+
 tags:
   - name: Rooms
     description: 호실 관련 API
@@ -852,3 +1176,5 @@ tags:
     description: 공지사항 관련 API
   - name: Calendar
     description: 캘린더 일정 관련 API
+  - name: Notifications
+    description: FCM 푸시 알림 관련 API

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,6 @@
 supabase
 black
 boto3
+requests
+google-auth
+google-auth-oauthlib

--- a/serverless.yml
+++ b/serverless.yml
@@ -16,6 +16,7 @@ package:
     - "!legacy_web_scraper/**"
     - "!layer/**"
     - "!envs/**"
+    - "envs/firebase-service-account.json"
     - "!.git/**"
     - "!.gitignore"
     - "!requirements.txt"
@@ -38,6 +39,9 @@ provider:
     SUPABASE_API_KEY: ${file(envs/config.${self:provider.stage}.json):SUPABASE_API_KEY}
     API_GATEWAY_ID: ${file(envs/config.${self:provider.stage}.json):API_GATEWAY_ID}
     BILL_BUCKET_NAME: ${file(envs/config.${self:provider.stage}.json):BILL_BUCKET_NAME}
+    FCM_SERVICE_ACCOUNT_PATH: ${file(envs/config.${self:provider.stage}.json):FCM_SERVICE_ACCOUNT_PATH}
+    FCM_PROJECT_ID: ${file(envs/config.${self:provider.stage}.json):FCM_PROJECT_ID}
+    WEBHOOK_SECRET: ${file(envs/config.${self:provider.stage}.json):WEBHOOK_SECRET}
 
 layers:
   AppDependencies:
@@ -231,3 +235,46 @@ functions:
       - httpApi:
           method: get
           path: /bill/image
+
+  # FCM 구독 관리 API
+  createSubscription:
+    name: ${self:provider.stage}-api-createSubscription
+    handler: src.handlers.subscriptions_handler.create_subscription_handler
+    layers:
+      - { Ref: AppDependenciesLambdaLayer }
+    events:
+      - httpApi:
+          method: post
+          path: /subscriptions
+
+  getSubscriptionStatus:
+    name: ${self:provider.stage}-api-getSubscriptionStatus
+    handler: src.handlers.subscriptions_handler.get_subscription_status_handler
+    layers:
+      - { Ref: AppDependenciesLambdaLayer }
+    events:
+      - httpApi:
+          method: get
+          path: /subscriptions/status
+
+  # FCM 알림 발송 API
+  sendNotification:
+    name: ${self:provider.stage}-api-sendNotification
+    handler: src.handlers.notifications_handler.send_notification_handler
+    layers:
+      - { Ref: AppDependenciesLambdaLayer }
+    events:
+      - httpApi:
+          method: post
+          path: /notifications
+
+  # Supabase 웹훅 엔드포인트
+  webhookNotify:
+    name: ${self:provider.stage}-api-webhookNotify
+    handler: src.handlers.notifications_handler.webhook_handler
+    layers:
+      - { Ref: AppDependenciesLambdaLayer }
+    events:
+      - httpApi:
+          method: post
+          path: /webhook/notify

--- a/src/dto/__init__.py
+++ b/src/dto/__init__.py
@@ -21,6 +21,11 @@ from .calendar_dto import (
     CalendarCreateRequestDTO,
     CalendarUpdateRequestDTO,
 )
+from .notification_dto import (
+    SubscriptionDTO,
+    SubscriptionCreateRequestDTO,
+    NotificationLogDTO,
+)
 
 __all__ = [
     "BaseDTO",
@@ -42,4 +47,7 @@ __all__ = [
     "CalendarListDTO",
     "CalendarCreateRequestDTO",
     "CalendarUpdateRequestDTO",
+    "SubscriptionDTO",
+    "SubscriptionCreateRequestDTO",
+    "NotificationLogDTO",
 ]

--- a/src/dto/notification_dto.py
+++ b/src/dto/notification_dto.py
@@ -1,0 +1,79 @@
+"""
+알림 관련 DTO 정의
+"""
+
+from typing import Optional
+from dataclasses import dataclass
+from .base_dto import BaseDTO
+
+
+@dataclass
+class SubscriptionDTO(BaseDTO):
+    """FCM 구독 정보 DTO"""
+
+    id: int
+    fcm_token: str
+    student_no: str
+    is_active: bool
+    platform: str
+    created_at: str
+    updated_at: str
+
+    @classmethod
+    def from_supabase_data(cls, data: dict) -> "SubscriptionDTO":
+        """Supabase 응답 데이터를 DTO로 변환"""
+        return cls(
+            id=data.get("id"),
+            fcm_token=data.get("fcm_token"),
+            student_no=data.get("student_no"),
+            is_active=data.get("is_active", False),
+            platform=data.get("platform", "web"),
+            created_at=data.get("created_at"),
+            updated_at=data.get("updated_at"),
+        )
+
+
+@dataclass
+class SubscriptionCreateRequestDTO(BaseDTO):
+    """FCM 구독 생성 요청 DTO"""
+
+    fcm_token: str
+    student_no: str
+    platform: str = "web"
+
+    def validate(self) -> tuple[bool, Optional[str]]:
+        """요청 데이터 검증"""
+        if not self.fcm_token or not self.fcm_token.strip():
+            return False, "fcm_token is required"
+
+        if not self.student_no or not self.student_no.strip():
+            return False, "student_no is required"
+
+        if self.platform not in ["web", "android", "ios"]:
+            return False, "platform must be one of: web, android, ios"
+
+        return True, None
+
+
+@dataclass
+class NotificationLogDTO(BaseDTO):
+    """알림 발송 결과 로그 DTO"""
+
+    id: int
+    notice_id: int
+    subscription_id: int
+    status: str
+    error_message: Optional[str]
+    sent_at: str
+
+    @classmethod
+    def from_supabase_data(cls, data: dict) -> "NotificationLogDTO":
+        """Supabase 응답 데이터를 DTO로 변환"""
+        return cls(
+            id=data.get("id"),
+            notice_id=data.get("notice_id"),
+            subscription_id=data.get("subscription_id"),
+            status=data.get("status"),
+            error_message=data.get("error_message"),
+            sent_at=data.get("sent_at"),
+        )

--- a/src/handlers/notifications_handler.py
+++ b/src/handlers/notifications_handler.py
@@ -1,0 +1,123 @@
+"""
+FCM 알림 발송 핸들러
+"""
+
+import json
+import logging
+import os
+from src.utils.responses import create_success_response, create_error_response
+from src.services.notifications_service import send_notification_to_all
+
+# 로거 설정
+logger = logging.getLogger()
+logger.setLevel(logging.INFO)
+
+
+def send_notification_handler(event, context):
+    """
+    수동으로 알림을 발송합니다.
+
+    POST /notifications
+    Body: {
+        "title": "string",
+        "content": "string",
+        "notice_id": 123
+    }
+    """
+    try:
+        logger.info("수동 알림 발송 요청 수신")
+
+        # 1. JSON 파싱
+        try:
+            body = json.loads(event.get("body", "{}"))
+        except json.JSONDecodeError:
+            logger.error("❌ 잘못된 JSON 형식")
+            return create_error_response("Invalid JSON format.", 400)
+
+        # 2. 필수 필드 검증
+        title = body.get("title")
+        content = body.get("content")
+        notice_id = body.get("notice_id")
+
+        if not title or not content or not notice_id:
+            logger.error("❌ 필수 필드 누락: title, content, notice_id")
+            return create_error_response(
+                "Missing required fields: title, content, notice_id", 400
+            )
+
+        # 3. 서비스 호출
+        result, error = send_notification_to_all(title, content, notice_id)
+        if error:
+            logger.error(f"❌ 알림 발송 실패: {error}")
+            return create_error_response(error, 500)
+
+        # 4. 성공 응답
+        logger.info(
+            f"✅ 수동 알림 발송 완료: 성공={result['success_count']}, 실패={result['failure_count']}"
+        )
+        return create_success_response(result)
+
+    except Exception as e:
+        logger.error(f"❌ 수동 알림 발송 핸들러 오류: {e}")
+        return create_error_response("Internal server error", 500)
+
+
+def webhook_handler(event, context):
+    """
+    Supabase 웹훅을 처리합니다.
+
+    POST /webhook/notify
+    Headers: X-Webhook-Secret
+    Body: Supabase webhook payload
+    """
+    try:
+        logger.info("Supabase 웹훅 요청 수신")
+
+        # 1. 웹훅 시크릿 검증
+        headers = event.get("headers", {})
+        webhook_secret = headers.get("x-webhook-secret")
+        expected_secret = os.environ.get("WEBHOOK_SECRET")
+
+        if not webhook_secret or webhook_secret != expected_secret:
+            logger.error("❌ 잘못된 웹훅 시크릿")
+            return create_error_response("Unauthorized", 401)
+
+        # 2. 웹훅 페이로드 파싱
+        try:
+            payload = json.loads(event.get("body", "{}"))
+        except json.JSONDecodeError:
+            logger.error("❌ 잘못된 웹훅 JSON 형식")
+            return create_error_response("Invalid JSON format.", 400)
+
+        # 3. INSERT 이벤트 확인
+        event_type = payload.get("type")
+        if event_type != "INSERT":
+            logger.info(f"⚠️ INSERT 이벤트가 아님: {event_type}")
+            return create_success_response({"message": "Event ignored"})
+
+        # 4. 공지사항 데이터 추출
+        record = payload.get("record", {})
+        notice_id = record.get("id")
+        title = record.get("title")
+        content = record.get("content")
+
+        if not notice_id or not title or not content:
+            logger.error("❌ 공지사항 데이터 누락")
+            return create_error_response("Missing notice data", 400)
+
+        # 5. 알림 발송
+        logger.info(f"📢 새 공지사항 알림 발송: id={notice_id}, title={title}")
+        result, error = send_notification_to_all(title, content, notice_id)
+        if error:
+            logger.error(f"❌ 웹훅 알림 발송 실패: {error}")
+            return create_error_response(error, 500)
+
+        # 6. 성공 응답
+        logger.info(
+            f"✅ 웹훅 알림 발송 완료: 성공={result['success_count']}, 실패={result['failure_count']}"
+        )
+        return create_success_response(result)
+
+    except Exception as e:
+        logger.error(f"❌ 웹훅 핸들러 오류: {e}")
+        return create_error_response("Internal server error", 500)

--- a/src/handlers/subscriptions_handler.py
+++ b/src/handlers/subscriptions_handler.py
@@ -1,0 +1,99 @@
+"""
+FCM 구독 관리 핸들러
+"""
+
+import json
+import logging
+from src.utils.responses import create_success_response, create_error_response
+from src.services.subscriptions_service import (
+    create_subscription,
+    get_subscription_status,
+)
+from src.dto.notification_dto import SubscriptionCreateRequestDTO
+
+# 로거 설정
+logger = logging.getLogger()
+logger.setLevel(logging.INFO)
+
+
+def create_subscription_handler(event, context):
+    """
+    FCM 구독을 생성합니다.
+
+    POST /subscriptions
+    Body: {
+        "fcm_token": "string",
+        "student_no": "string",
+        "platform": "web"
+    }
+    """
+    try:
+        logger.info("FCM 구독 생성 요청 수신")
+
+        # 1. JSON 파싱
+        try:
+            body = json.loads(event.get("body", "{}"))
+        except json.JSONDecodeError:
+            logger.error("❌ 잘못된 JSON 형식")
+            return create_error_response("Invalid JSON format.", 400)
+
+        # 2. DTO 생성 및 검증
+        try:
+            request_dto = SubscriptionCreateRequestDTO(
+                fcm_token=body.get("fcm_token"),
+                student_no=body.get("student_no"),
+                platform=body.get("platform", "web"),
+            )
+        except Exception as e:
+            logger.error(f"❌ DTO 생성 실패: {e}")
+            return create_error_response(f"Invalid request data: {str(e)}", 400)
+
+        # 3. 서비스 호출
+        subscription_dto, error = create_subscription(request_dto)
+        if error:
+            logger.error(f"❌ 구독 생성 실패: {error}")
+            return create_error_response(error, 500)
+
+        # 4. 성공 응답
+        logger.info(f"✅ FCM 구독 생성 완료: id={subscription_dto.id}")
+        return create_success_response(subscription_dto.to_dict())
+
+    except Exception as e:
+        logger.error(f"❌ 구독 생성 핸들러 오류: {e}")
+        return create_error_response("Internal server error", 500)
+
+
+def get_subscription_status_handler(event, context):
+    """
+    FCM 구독 상태를 조회합니다.
+
+    GET /subscriptions/status?fcm_token=xxx
+    """
+    try:
+        logger.info("FCM 구독 상태 조회 요청 수신")
+
+        # 1. 쿼리 파라미터 추출
+        query_params = event.get("queryStringParameters") or {}
+        fcm_token = query_params.get("fcm_token")
+
+        if not fcm_token:
+            logger.error("❌ fcm_token 파라미터 누락")
+            return create_error_response("fcm_token parameter is required", 400)
+
+        # 2. 서비스 호출
+        status_data, error = get_subscription_status(fcm_token)
+        if error:
+            if "not found" in error.lower():
+                logger.info(f"⚠️ 구독을 찾을 수 없음: fcm_token={fcm_token[:20]}...")
+                return create_error_response("Subscription not found", 404)
+            else:
+                logger.error(f"❌ 구독 상태 조회 실패: {error}")
+                return create_error_response(error, 500)
+
+        # 3. 성공 응답
+        logger.info(f"✅ FCM 구독 상태 조회 완료: active={status_data['active']}")
+        return create_success_response(status_data)
+
+    except Exception as e:
+        logger.error(f"❌ 구독 상태 조회 핸들러 오류: {e}")
+        return create_error_response("Internal server error", 500)

--- a/src/services/notifications_service.py
+++ b/src/services/notifications_service.py
@@ -1,0 +1,217 @@
+"""
+FCM 알림 발송 서비스
+"""
+
+import logging
+from typing import List, Tuple, Optional
+from src.utils.supabase_client import get_supabase_client
+from src.utils.fcm_client import send_multicast_notification
+from src.dto.notification_dto import SubscriptionDTO, NotificationLogDTO
+
+# 로거 설정
+logger = logging.getLogger()
+logger.setLevel(logging.INFO)
+
+
+def get_active_subscriptions() -> Tuple[List[SubscriptionDTO], Optional[str]]:
+    """
+    활성화된 모든 FCM 구독을 조회합니다.
+
+    Returns:
+        (SubscriptionDTO 리스트, 에러 메시지)
+    """
+    try:
+        supabase = get_supabase_client("notify")
+        if not supabase:
+            return [], "Supabase client could not be initialized."
+
+        logger.info("활성화된 FCM 구독 조회 중...")
+
+        response = (
+            supabase.postgrest.schema("notify")
+            .from_("subscriptions")
+            .select(
+                "id, fcm_token, student_no, is_active, platform, created_at, updated_at"
+            )
+            .eq("is_active", True)
+            .execute()
+        )
+
+        if response.data:
+            subscriptions = [
+                SubscriptionDTO.from_supabase_data(sub_data)
+                for sub_data in response.data
+            ]
+            logger.info(f"✅ 활성화된 FCM 구독 {len(subscriptions)}개 조회 완료")
+            return subscriptions, None
+        else:
+            logger.info("⚠️ 활성화된 FCM 구독이 없습니다.")
+            return [], None
+
+    except Exception as e:
+        logger.error(f"❌ 활성화된 FCM 구독 조회 실패: {e}")
+        error_message = getattr(e, "message", str(e))
+        return [], error_message
+
+
+def send_notification_to_all(
+    title: str, content: str, notice_id: int
+) -> Tuple[dict, Optional[str]]:
+    """
+    모든 활성화된 구독자에게 알림을 발송합니다.
+
+    Args:
+        title: 알림 제목
+        content: 알림 내용
+        notice_id: 공지사항 ID
+
+    Returns:
+        (발송 결과 딕셔너리, 에러 메시지)
+    """
+    try:
+        logger.info(f"전체 알림 발송 시작: title={title}, notice_id={notice_id}")
+
+        # 1. 활성화된 구독 조회
+        subscriptions, error = get_active_subscriptions()
+        if error:
+            return {"success": False, "error": error}, error
+
+        if not subscriptions:
+            logger.info("⚠️ 발송할 활성 구독이 없습니다.")
+            return {
+                "success": True,
+                "total_subscriptions": 0,
+                "success_count": 0,
+                "failure_count": 0,
+                "invalid_tokens": [],
+                "failed_tokens": [],
+            }, None
+
+        # 2. FCM 토큰 추출
+        fcm_tokens = [sub.fcm_token for sub in subscriptions]
+        logger.info(f"📤 {len(fcm_tokens)}개 토큰으로 알림 발송 시작")
+
+        # 3. FCM 멀티캐스트 발송
+        success_count, failure_count, failed_tokens, invalid_tokens = (
+            send_multicast_notification(fcm_tokens, title, content)
+        )
+
+        # 4. 무효 토큰 구독 비활성화 및 로그 기록
+        if invalid_tokens:
+            logger.info(f"🔄 무효 토큰 {len(invalid_tokens)}개 구독 비활성화 시작")
+            from src.services.subscriptions_service import (
+                deactivate_invalid_subscription,
+            )
+
+            for subscription in subscriptions:
+                if subscription.fcm_token in invalid_tokens:
+                    deactivate_success, deactivate_error = (
+                        deactivate_invalid_subscription(subscription.id)
+                    )
+                    if deactivate_success:
+                        logger.info(
+                            f"✅ 구독 {subscription.id} 비활성화 완료 (무효 토큰)"
+                        )
+                    else:
+                        logger.warning(
+                            f"⚠️ 구독 {subscription.id} 비활성화 실패: {deactivate_error}"
+                        )
+
+        # 5. 각 구독별 발송 결과 로그 기록
+        logger.info("📝 알림 발송 결과 로그 기록 시작")
+        for subscription in subscriptions:
+            if subscription.fcm_token in invalid_tokens:
+                # 무효 토큰
+                log_success, log_error = log_notification_result(
+                    notice_id, subscription.id, "invalid_token", "Invalid FCM token"
+                )
+            elif subscription.fcm_token in failed_tokens:
+                # 발송 실패
+                log_success, log_error = log_notification_result(
+                    notice_id, subscription.id, "failed", "FCM send failed"
+                )
+            else:
+                # 발송 성공
+                log_success, log_error = log_notification_result(
+                    notice_id, subscription.id, "success"
+                )
+
+            if log_success:
+                logger.info(f"✅ 구독 {subscription.id} 로그 기록 완료")
+            else:
+                logger.warning(f"⚠️ 구독 {subscription.id} 로그 기록 실패: {log_error}")
+
+        # 6. 결과 반환
+        result = {
+            "success": True,
+            "total_subscriptions": len(subscriptions),
+            "success_count": success_count,
+            "failure_count": failure_count,
+            "invalid_tokens": invalid_tokens,
+            "failed_tokens": failed_tokens,
+        }
+
+        logger.info(
+            f"✅ 전체 알림 발송 완료: 성공={success_count}, 실패={failure_count}, 무효={len(invalid_tokens)}"
+        )
+
+        return result, None
+
+    except Exception as e:
+        logger.error(f"❌ 전체 알림 발송 실패: {e}")
+        error_message = getattr(e, "message", str(e))
+        return {"success": False, "error": error_message}, error_message
+
+
+def log_notification_result(
+    notice_id: int,
+    subscription_id: int,
+    status: str,
+    error_message: Optional[str] = None,
+) -> Tuple[bool, Optional[str]]:
+    """
+    알림 발송 결과를 로그에 기록합니다.
+
+    Args:
+        notice_id: 공지사항 ID
+        subscription_id: 구독 ID
+        status: 발송 상태 (success, failed, invalid_token)
+        error_message: 에러 메시지 (실패 시)
+
+    Returns:
+        (성공 여부, 에러 메시지)
+    """
+    try:
+        supabase = get_supabase_client("notify")
+        if not supabase:
+            return False, "Supabase client could not be initialized."
+
+        logger.info(
+            f"알림 발송 결과 로깅: notice_id={notice_id}, subscription_id={subscription_id}, status={status}"
+        )
+
+        insert_data = {
+            "notice_id": notice_id,
+            "subscription_id": subscription_id,
+            "status": status,
+            "error_message": error_message,
+        }
+
+        response = (
+            supabase.postgrest.schema("notify")
+            .from_("notice_logs")
+            .insert(insert_data)
+            .execute()
+        )
+
+        if response.data:
+            logger.info(f"✅ 알림 발송 결과 로깅 완료: id={response.data[0].get('id')}")
+            return True, None
+        else:
+            logger.error("❌ 알림 발송 결과 로깅 실패: 응답 데이터가 없습니다.")
+            return False, "Failed to log notification result"
+
+    except Exception as e:
+        logger.error(f"❌ 알림 발송 결과 로깅 실패: {e}")
+        error_message = getattr(e, "message", str(e))
+        return False, error_message

--- a/src/services/subscriptions_service.py
+++ b/src/services/subscriptions_service.py
@@ -1,0 +1,162 @@
+"""
+FCM 구독 관리 서비스
+"""
+
+import logging
+from typing import Optional, Tuple
+from src.utils.supabase_client import get_supabase_client
+from src.dto.notification_dto import SubscriptionDTO, SubscriptionCreateRequestDTO
+
+# 로거 설정
+logger = logging.getLogger()
+logger.setLevel(logging.INFO)
+
+
+def create_subscription(
+    request_dto: SubscriptionCreateRequestDTO,
+) -> Tuple[Optional[SubscriptionDTO], Optional[str]]:
+    """
+    FCM 구독을 생성하거나 업데이트합니다.
+
+    Args:
+        request_dto: 구독 생성 요청 DTO
+
+    Returns:
+        (SubscriptionDTO, 에러 메시지)
+    """
+    try:
+        supabase = get_supabase_client("notify")
+        if not supabase:
+            return None, "Supabase client could not be initialized."
+
+        logger.info(
+            f"FCM 구독 생성/업데이트: fcm_token={request_dto.fcm_token[:20]}..."
+        )
+
+        # 데이터 검증
+        is_valid, error_msg = request_dto.validate()
+        if not is_valid:
+            return None, error_msg
+
+        # UPSERT로 중복 방지 (fcm_token UNIQUE 제약 활용)
+        insert_data = {
+            "fcm_token": request_dto.fcm_token,
+            "student_no": request_dto.student_no,
+            "platform": request_dto.platform,
+            "is_active": True,
+        }
+
+        response = (
+            supabase.postgrest.schema("notify")
+            .from_("subscriptions")
+            .upsert(insert_data, on_conflict="fcm_token", returning="representation")
+            .execute()
+        )
+
+        if response.data:
+            subscription_dto = SubscriptionDTO.from_supabase_data(response.data[0])
+            logger.info(
+                f"✅ FCM 구독이 성공적으로 생성/업데이트되었습니다: id={subscription_dto.id}"
+            )
+            return subscription_dto, None
+        else:
+            logger.error("❌ FCM 구독 생성/업데이트 실패: 응답 데이터가 없습니다.")
+            return None, "Failed to create/update subscription"
+
+    except Exception as e:
+        logger.error(f"❌ FCM 구독 생성/업데이트 실패: {e}")
+        error_message = getattr(e, "message", str(e))
+        return None, error_message
+
+
+def get_subscription_status(fcm_token: str) -> Tuple[Optional[dict], Optional[str]]:
+    """
+    FCM 구독 상태를 조회합니다.
+
+    Args:
+        fcm_token: FCM 토큰
+
+    Returns:
+        (구독 상태 딕셔너리, 에러 메시지)
+    """
+    try:
+        supabase = get_supabase_client("notify")
+        if not supabase:
+            return None, "Supabase client could not be initialized."
+
+        logger.info(f"FCM 구독 상태 조회: fcm_token={fcm_token[:20]}...")
+
+        if not fcm_token or not fcm_token.strip():
+            return None, "fcm_token is required"
+
+        response = (
+            supabase.postgrest.schema("notify")
+            .from_("subscriptions")
+            .select(
+                "id, fcm_token, student_no, is_active, platform, created_at, updated_at"
+            )
+            .eq("fcm_token", fcm_token)
+            .execute()
+        )
+
+        if response.data:
+            subscription_data = response.data[0]
+            status = {
+                "active": subscription_data.get("is_active", False),
+                "subscription_id": subscription_data.get("id"),
+                "student_no": subscription_data.get("student_no"),
+                "platform": subscription_data.get("platform"),
+                "created_at": subscription_data.get("created_at"),
+                "updated_at": subscription_data.get("updated_at"),
+            }
+            logger.info(f"✅ FCM 구독 상태 조회 완료: active={status['active']}")
+            return status, None
+        else:
+            logger.info(
+                f"❌ FCM 구독을 찾을 수 없습니다: fcm_token={fcm_token[:20]}..."
+            )
+            return None, "Subscription not found"
+
+    except Exception as e:
+        logger.error(f"❌ FCM 구독 상태 조회 실패: {e}")
+        error_message = getattr(e, "message", str(e))
+        return None, error_message
+
+
+def deactivate_invalid_subscription(subscription_id: int) -> Tuple[bool, Optional[str]]:
+    """
+    무효한 구독을 비활성화합니다.
+
+    Args:
+        subscription_id: 구독 ID
+
+    Returns:
+        (성공 여부, 에러 메시지)
+    """
+    try:
+        supabase = get_supabase_client("notify")
+        if not supabase:
+            return False, "Supabase client could not be initialized."
+
+        logger.info(f"구독 비활성화: subscription_id={subscription_id}")
+
+        response = (
+            supabase.postgrest.schema("notify")
+            .from_("subscriptions")
+            .update({"is_active": False})
+            .eq("id", subscription_id)
+            .select()
+            .execute()
+        )
+
+        if response.data:
+            logger.info(f"✅ 구독 {subscription_id}이 성공적으로 비활성화되었습니다.")
+            return True, None
+        else:
+            logger.warning(f"⚠️ 구독 {subscription_id}을 찾을 수 없습니다.")
+            return False, "Subscription not found"
+
+    except Exception as e:
+        logger.error(f"❌ 구독 비활성화 실패: {e}")
+        error_message = getattr(e, "message", str(e))
+        return False, error_message

--- a/src/utils/fcm_client.py
+++ b/src/utils/fcm_client.py
@@ -1,0 +1,271 @@
+"""
+Firebase Cloud Messaging HTTP v1 API 클라이언트
+"""
+
+import os
+import json
+import logging
+from typing import Optional, Dict, Any, List, Tuple
+import requests
+from google.auth.transport.requests import Request
+from google.oauth2 import service_account
+
+# 로거 설정
+logger = logging.getLogger()
+logger.setLevel(logging.INFO)
+
+# FCM HTTP v1 API 엔드포인트
+FCM_API_URL = "https://fcm.googleapis.com/v1/projects/{project_id}/messages:send"
+
+# OAuth 2.0 인증 정보 캐시
+_credentials = None
+_access_token = None
+
+
+def get_fcm_credentials():
+    """Firebase 서비스 계정 인증 정보를 가져옵니다."""
+    global _credentials
+
+    if _credentials is None:
+        try:
+            # 환경변수에서 서비스 계정 JSON 파일 경로 가져오기
+            service_account_path = os.environ.get("FCM_SERVICE_ACCOUNT_PATH")
+            if not service_account_path:
+                raise ValueError(
+                    "FCM_SERVICE_ACCOUNT_PATH environment variable is required"
+                )
+
+            # 서비스 계정 JSON 파일 읽기
+            with open(service_account_path, "r") as f:
+                service_account_info = json.load(f)
+
+            # 서비스 계정 인증 정보 생성
+            _credentials = service_account.Credentials.from_service_account_info(
+                service_account_info,
+                scopes=["https://www.googleapis.com/auth/cloud-platform"],
+            )
+
+            logger.info("✅ Firebase 서비스 계정 인증 정보가 로드되었습니다.")
+
+        except Exception as e:
+            logger.error(f"❌ Firebase 서비스 계정 인증 정보 로드 실패: {e}")
+            raise
+
+    return _credentials
+
+
+def get_access_token():
+    """OAuth 2.0 액세스 토큰을 가져옵니다."""
+    global _access_token
+
+    credentials = get_fcm_credentials()
+
+    # 토큰이 없거나 만료된 경우 새로 발급
+    if not _access_token or credentials.expired:
+        try:
+            credentials.refresh(Request())
+            _access_token = credentials.token
+            logger.info("✅ FCM 액세스 토큰이 갱신되었습니다.")
+        except Exception as e:
+            logger.error(f"❌ FCM 액세스 토큰 발급 실패: {e}")
+            raise
+
+    return _access_token
+
+
+def send_notification(
+    fcm_token: str, title: str, body: str, data: Optional[Dict[str, str]] = None
+) -> Tuple[bool, Optional[str]]:
+    """
+    단일 FCM 토큰으로 알림을 발송합니다.
+
+    Args:
+        fcm_token: FCM 토큰
+        title: 알림 제목
+        body: 알림 내용
+        data: 추가 데이터 (옵션)
+
+    Returns:
+        (성공 여부, 에러 메시지)
+    """
+    try:
+        project_id = os.environ.get("FCM_PROJECT_ID")
+        if not project_id:
+            return False, "FCM_PROJECT_ID environment variable is required"
+
+        access_token = get_access_token()
+
+        # FCM HTTP v1 API 메시지 구성
+        message = {
+            "message": {
+                "token": fcm_token,
+                "notification": {"title": title, "body": body},
+                "data": data or {},
+                "webpush": {
+                    "fcm_options": {
+                        "link": (
+                            f"https://yourdomain.com/notice/{data.get('notice_id', '')}"
+                            if data
+                            else None
+                        )
+                    }
+                },
+            }
+        }
+
+        # HTTP 요청 헤더
+        headers = {
+            "Authorization": f"Bearer {access_token}",
+            "Content-Type": "application/json",
+        }
+
+        # FCM API 호출
+        url = FCM_API_URL.format(project_id=project_id)
+        response = requests.post(url, headers=headers, json=message)
+
+        if response.status_code == 200:
+            logger.info(f"✅ FCM 메시지 발송 성공: {fcm_token[:20]}...")
+            return True, None
+        else:
+            error_data = response.json()
+            error_message = error_data.get("error", {}).get("message", "Unknown error")
+            logger.error(f"❌ FCM 메시지 발송 실패: {error_message}")
+            return False, error_message
+
+    except Exception as e:
+        logger.error(f"❌ FCM 메시지 발송 중 오류: {e}")
+        return False, str(e)
+
+
+def send_multicast_notification(
+    fcm_tokens: List[str], title: str, body: str, data: Optional[Dict[str, str]] = None
+) -> Tuple[int, int, List[str], List[str]]:
+    """
+    여러 FCM 토큰으로 멀티캐스트 알림을 발송합니다.
+
+    Args:
+        fcm_tokens: FCM 토큰 리스트
+        title: 알림 제목
+        body: 알림 내용
+        data: 추가 데이터 (옵션)
+
+    Returns:
+        (성공 수, 실패 수, 실패한 토큰 리스트, 무효 토큰 리스트)
+    """
+    try:
+        project_id = os.environ.get("FCM_PROJECT_ID")
+        if not project_id:
+            logger.error("FCM_PROJECT_ID environment variable is required")
+            return 0, len(fcm_tokens), fcm_tokens, []
+
+        access_token = get_access_token()
+
+        success_count = 0
+        failure_count = 0
+        failed_tokens = []
+        invalid_tokens = []
+
+        # HTTP 요청 헤더
+        headers = {
+            "Authorization": f"Bearer {access_token}",
+            "Content-Type": "application/json",
+        }
+
+        # 각 토큰에 대해 개별 메시지 전송
+        for fcm_token in fcm_tokens:
+            try:
+                # FCM HTTP v1 API 개별 메시지 구성
+                message = {
+                    "message": {
+                        "token": fcm_token,
+                        "notification": {"title": title, "body": body},
+                        "data": data or {},
+                        "webpush": {
+                            "fcm_options": {
+                                "link": (
+                                    f"https://yourdomain.com/notice/{data.get('notice_id', '')}"
+                                    if data
+                                    else None
+                                )
+                            }
+                        },
+                    }
+                }
+
+                # FCM API 호출
+                url = FCM_API_URL.format(project_id=project_id)
+                response = requests.post(url, headers=headers, json=message)
+
+                if response.status_code == 200:
+                    # 성공
+                    success_count += 1
+                    logger.info(f"✅ FCM 발송 성공: {fcm_token[:20]}...")
+                else:
+                    # 실패
+                    error_data = response.json()
+                    error = error_data.get("error", {})
+                    error_code = error.get("code")
+                    error_message = error.get("message", "Unknown error")
+
+                    failed_tokens.append(fcm_token)
+
+                    # 무효 토큰 판정
+                    if _is_invalid_token_error(error_code, error_message):
+                        invalid_tokens.append(fcm_token)
+                        logger.warning(
+                            f"❌ 무효 토큰: {fcm_token[:20]}... - {error_message}"
+                        )
+                    else:
+                        logger.warning(
+                            f"❌ FCM 발송 실패: {fcm_token[:20]}... - {error_message}"
+                        )
+
+                    failure_count += 1
+
+            except Exception as e:
+                logger.error(f"❌ FCM 토큰 {fcm_token[:20]}... 발송 중 오류: {e}")
+                failed_tokens.append(fcm_token)
+                failure_count += 1
+
+        logger.info(
+            f"📊 FCM 멀티캐스트 발송 완료: 성공 {success_count}개, 실패 {failure_count}개, 무효 {len(invalid_tokens)}개"
+        )
+
+        return success_count, failure_count, failed_tokens, invalid_tokens
+
+    except Exception as e:
+        logger.error(f"❌ FCM 멀티캐스트 발송 중 오류: {e}")
+        return 0, len(fcm_tokens), fcm_tokens, []
+
+
+def _is_invalid_token_error(error_code: str, error_message: str) -> bool:
+    """
+    에러가 무효 토큰 에러인지 판정합니다.
+
+    Args:
+        error_code: FCM API 에러 코드
+        error_message: 에러 메시지
+
+    Returns:
+        무효 토큰 여부
+    """
+    # 에러 코드 기반 판정
+    invalid_codes = ["INVALID_ARGUMENT", "UNREGISTERED", "SENDER_ID_MISMATCH"]
+
+    if error_code in invalid_codes:
+        return True
+
+    # 에러 메시지 기반 판정
+    invalid_keywords = [
+        "registration-token-not-registered",
+        "Invalid registration token",
+        "Sender ID mismatch",
+        "Unregistered",
+    ]
+
+    error_message_lower = error_message.lower()
+    for keyword in invalid_keywords:
+        if keyword.lower() in error_message_lower:
+            return True
+
+    return False


### PR DESCRIPTION
### 작업 요약
- **FCM HTTP v1**로 PWA 학생들에게 공지 알림 발송 기능 구현.
- 구독(토큰) 관리, 수동/자동(웹훅) 발송, 무효 토큰 자동 비활성화, 발송 결과 로깅 제공.

### 주요 변경 사항
- **알림 클라이언트**
  - `src/utils/fcm_client.py`: OAuth2 토큰 발급, 단건/멀티 발송, 무효 토큰 판정 로직.
- **서비스**
  - `src/services/subscriptions_service.py`: 구독 생성/업데이트(UPSERT), 상태 조회, 무효 토큰 비활성화.
  - `src/services/notifications_service.py`: 활성 구독 조회, 전송 오케스트레이션, `notify.notice_logs` 로깅.
- **핸들러**
  - `src/handlers/subscriptions_handler.py`: `POST /subscriptions`, `GET /subscriptions/status`.
  - `src/handlers/notifications_handler.py`: `POST /notifications`, `POST /webhook/notify`, `POST /webhook/test`.
- **DTO**
  - `src/dto/notification_dto.py`: `SubscriptionDTO`, `SubscriptionCreateRequestDTO`, `NotificationLogDTO` (+ `@dataclass`).
  - `src/dto/__init__.py`: 신규 DTO export 추가.
- **문서/배포**
  - `docs/openapi.yml`: 스키마와 경로 추가(Subscriptions/Notifications/Webhook).
  - `.github/workflows/deploy.yml`: Secrets(Base64) → `envs/firebase-service-account.json` 생성, 환경 파일 생성, 서버리스 배포.
  - `serverless.yml`: `envs/firebase-service-account.json`만 패키징에 포함, 환경변수 주입.

### 신규/변경 API
- `POST /subscriptions`
  - Body: `{ fcm_token, student_no, platform }`
  - 동작: 토큰 기준 UPSERT로 활성화/갱신
- `GET /subscriptions/status?fcm_token=...`
  - 동작: 구독 상태 조회
- `POST /notifications`
  - Body: `{ title, body, notice_id, data? }`
  - 동작: 활성 구독 전체 대상 수동 발송 + 결과 로깅
- `POST /webhook/notify`
  - Header: `x-webhook-secret: ${WEBHOOK_SECRET}`
  - Body: Supabase DB Webhook Payload
  - 동작: `core.notice` INSERT 이벤트 → 자동 발송

### 환경 변수 추가
- `FCM_PROJECT_ID`
- `FCM_SERVICE_ACCOUNT_PATH` = `envs/firebase-service-account.json`
- `WEBHOOK_SECRET`
- `FCM_SERVICE_ACCOUNT_JSON` 파일

### CI/CD (GitHub Actions)
- `FIREBASE_SERVICE_ACCOUNT_JSON` 시크릿을 디코드해 `envs/firebase-service-account.json` 생성.
- `envs/config.dev.json`/`envs/config.prod.json` 생성 시 `FCM_SERVICE_ACCOUNT_PATH`를 동일 경로로 설정.
- `serverless.yml`에서 `envs/firebase-service-account.json`만 패키징 포함.

### 데이터 처리/로깅
- 전송 결과를 `notify.notice_logs`에 기록.
- FCM 응답의 코드/메시지 기반으로 무효 토큰 판정 → `notify.subscriptions.is_active=false` 자동 비활성화.

### 테스트 가이드

**토큰 등록**
   - 프론트(PWA)에서 FCM 토큰 발급 후 `POST /subscriptions` 호출.

**자동 발송 확인**
   - Supabase에서 `core.notice`에 INSERT → 웹훅 → 알림 수신 및 `notify.notice_logs` 기록 확인.