### PR TITLE
feat: 관리자/학생 인증 분리 및 환경변수 관리 개선

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -61,14 +61,14 @@ jobs:
         if: env.STAGE == 'dev'
         run: |
           mkdir -p envs
-          echo '{ "SUPABASE_URL": "${{ secrets.DEV_SUPABASE_URL }}","SUPABASE_API_KEY": "${{ secrets.DEV_SUPABASE_API_KEY }}", "API_GATEWAY_ID": "${{ secrets.DEV_API_GATEWAY_ID }}", "BILL_BUCKET_NAME": "${{ secrets.DEV_BILL_BUCKET_NAME }}", "FCM_SERVICE_ACCOUNT_PATH": "envs/dev-firebase-service-account.json", "FCM_PROJECT_ID": "${{ secrets.DEV_FCM_PROJECT_ID }}", "WEBHOOK_SECRET": "${{ secrets.DEV_WEBHOOK_SECRET }}", "COGNITO_DOMAIN": "${{ secrets.DEV_COGNITO_DOMAIN }}", "COGNITO_CLIENT_ID": "${{ secrets.DEV_COGNITO_CLIENT_ID }}", "CALLBACK_URI": "${{ secrets.DEV_CALLBACK_URI }}", "COOKIE_SECURE": "${{ secrets.DEV_COOKIE_SECURE }}", "SESSION_TABLE": "${{ secrets.DEV_SESSION_TABLE }}", "SESSION_TTL_SECONDS": "${{ secrets.DEV_SESSION_TTL_SECONDS }}", "SESSION_COOKIE_TTL_SECONDS": "${{ secrets.DEV_SESSION_COOKIE_TTL_SECONDS }}", "PERSIST_COOKIE_TTL_SECONDS": "${{ secrets.DEV_PERSIST_COOKIE_TTL_SECONDS }}", "ALLOWED_REDIRECT_ORIGINS": "${{ secrets.DEV_ALLOWED_REDIRECT_ORIGINS }}", "ALLOWED_LOGOUT_URLS": "${{ secrets.DEV_ALLOWED_LOGOUT_URLS }}", "CORS_ORIGINS": [ ${{ secrets.DEV_CORS_ORIGINS }} ] }' > envs/config.dev.json
+          printf %s "${{ secrets.DEV_CONFIG_JSON }}" | base64 --decode > envs/config.dev.json
 
       # 6-2. prod 환경 설정 파일 생성 (이후 실제 PROD DB 연결이 필요함)
       - name: Create PROD environment file
         if: env.STAGE == 'prod'
         run: |
           mkdir -p envs
-          echo '{ "SUPABASE_URL": "${{ secrets.PROD_SUPABASE_URL }}", "SUPABASE_API_KEY": "${{ secrets.PROD_SUPABASE_API_KEY }}", "API_GATEWAY_ID": "${{ secrets.PROD_API_GATEWAY_ID }}", "BILL_BUCKET_NAME": "${{ secrets.PROD_BILL_BUCKET_NAME }}", "FCM_SERVICE_ACCOUNT_PATH": "envs/prod-firebase-service-account.json", "FCM_PROJECT_ID": "${{ secrets.PROD_FCM_PROJECT_ID }}", "WEBHOOK_SECRET": "${{ secrets.PROD_WEBHOOK_SECRET }}", "COGNITO_DOMAIN": "${{ secrets.PROD_COGNITO_DOMAIN }}", "COGNITO_CLIENT_ID": "${{ secrets.PROD_COGNITO_CLIENT_ID }}", "CALLBACK_URI": "${{ secrets.PROD_CALLBACK_URI }}", "COOKIE_SECURE": "${{ secrets.PROD_COOKIE_SECURE }}", "SESSION_TABLE": "${{ secrets.PROD_SESSION_TABLE }}", "SESSION_TTL_SECONDS": "${{ secrets.PROD_SESSION_TTL_SECONDS }}", "SESSION_COOKIE_TTL_SECONDS": "${{ secrets.PROD_SESSION_COOKIE_TTL_SECONDS }}", "PERSIST_COOKIE_TTL_SECONDS": "${{ secrets.PROD_PERSIST_COOKIE_TTL_SECONDS }}", "ALLOWED_REDIRECT_ORIGINS": "${{ secrets.PROD_ALLOWED_REDIRECT_ORIGINS }}", "ALLOWED_LOGOUT_URLS": "${{ secrets.PROD_ALLOWED_LOGOUT_URLS }}", "CORS_ORIGINS": [ ${{ secrets.PROD_CORS_ORIGINS }} ] }' > envs/config.prod.json
+          printf %s "${{ secrets.PROD_CONFIG_JSON }}" | base64 --decode > envs/config.prod.json
 
       # 7. Python Lambda Layer 빌드
       # 우리가 찾은, Docker 없이 Linux 호환 라이브러리를 설치하는 명령어 실행

--- a/docs/openapi.yml
+++ b/docs/openapi.yml
@@ -6,10 +6,12 @@ info:
     국민대학교 스마트 기숙사 관리 시스템 API
     먼저 로그인을 통해 세션을 발급받아야 합니다.
 
-    http://localhost:3000/auth/login
-
-    1. 위 링크에 접속해서 로그인 플로우를 시작합니다.
-    2. 로그인 성공 후 이 OpenAPI 문서로 리다이렉트 됩니다.
+    **인증 엔드포인트 사용 방법:**
+    - 인증 엔드포인트(`/auth/admin/login`, `/auth/user/login` 등)는 302 리다이렉트를 반환하므로
+      스웨거 UI에서 직접 테스트하기 어렵습니다.
+    - 실제 사용은 프론트엔드 애플리케이션에서 브라우저를 통해 리다이렉트 플로우로 진행됩니다.
+    - 프론트엔드에서 해당 엔드포인트를 호출하면 Cognito Hosted UI로 리다이렉트되고,
+      로그인 성공 후 지정한 redirect URL로 최종 리다이렉트됩니다.
   contact:
     name: KMU SDMS Team
 
@@ -947,6 +949,214 @@ paths:
               schema:
                 $ref: "#/components/schemas/Error"
 
+  /auth/admin/login:
+    get:
+      summary: 관리자 Cognito Hosted UI 로그인 시작
+      description: 관리자용 로그인 플로우를 시작합니다. 서버는 PKCE와 state를 설정하고 Cognito Hosted UI로 302 리다이렉트합니다. 기존 유효한 세션이 있으면 바로 리다이렉트합니다.
+      tags:
+        - Auth
+      security: []
+      parameters:
+        - name: redirect
+          in: query
+          description: 로그인 완료 후 리다이렉트할 절대 URL (허용된 관리자 오리진만)
+          required: false
+          schema:
+            type: string
+          examples:
+            adminPage:
+              value: "https://kmu-sdms-admin-page.vercel.app/home"
+            surge:
+              value: "https://kmu-sdbms-admin-page.surge.sh/home"
+            local:
+              value: "http://localhost:3000/docs"
+      responses:
+        "302":
+          description: Cognito Hosted UI로 리다이렉트 또는 기존 세션이 있으면 redirect 파라미터로 직접 리다이렉트
+        "400":
+          description: redirect 파라미터가 없거나 허용되지 않은 오리진
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "500":
+          description: 서버 내부 오류 (설정 누락 등)
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+
+  /auth/admin/callback:
+    get:
+      summary: 관리자 Cognito 콜백
+      description: Cognito가 관리자 인증 후 Authorization Code와 state를 전달하는 엔드포인트. 서버는 코드 교환 후 `session` 쿠키를 설정하고 최초 요청된 redirect(허용된 관리자 오리진)로 302 리다이렉트합니다.
+      tags:
+        - Auth
+      security: []
+      parameters:
+        - name: code
+          in: query
+          description: Cognito에서 전달받은 Authorization Code
+          required: true
+          schema:
+            type: string
+        - name: state
+          in: query
+          description: CSRF 방지를 위한 state 값
+          required: true
+          schema:
+            type: string
+      responses:
+        "302":
+          description: 로그인 완료 후 최종 리다이렉트
+        "400":
+          description: state/code 오류 또는 redirect 누락/허용되지 않은 오리진
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "500":
+          description: 토큰 교환 실패 또는 서버 내부 오류
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+
+  /auth/admin/logout:
+    get:
+      summary: 관리자 로그아웃
+      description: 관리자 세션을 삭제하고, 요청의 redirect 파라미터(절대 URL)가 허용된 관리자 오리진이며 Cognito에 사전 등록된 로그아웃 URL 목록에 존재하면 해당 URL로 최종 리다이렉트합니다.
+      tags:
+        - Auth
+      security: []
+      parameters:
+        - name: redirect
+          in: query
+          description: 로그아웃 완료 후 리다이렉트할 절대 URL (허용된 관리자 오리진 + Cognito 등록 URL)
+          required: false
+          schema:
+            type: string
+          examples:
+            adminPage:
+              value: "https://kmu-sdms-admin-page.vercel.app/auth"
+            surge:
+              value: "https://kmu-sdbms-admin-page.surge.sh/auth"
+            local:
+              value: "http://localhost:3000/auth"
+      responses:
+        "302":
+          description: 로그아웃 처리 후 최종 리다이렉트 또는 Cognito 로그아웃으로 리다이렉트
+        "400":
+          description: redirect 누락/허용되지 않은 오리진
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+
+  /auth/user/login:
+    get:
+      summary: 사용자 Cognito Hosted UI 로그인 시작
+      description: 사용자(학생)용 로그인 플로우를 시작합니다. 서버는 PKCE와 state를 설정하고 Cognito Hosted UI로 302 리다이렉트합니다. 기존 유효한 세션이 있으면 바로 리다이렉트합니다.
+      tags:
+        - Auth
+      security: []
+      parameters:
+        - name: redirect
+          in: query
+          description: 로그인 완료 후 리다이렉트할 절대 URL (허용된 사용자 오리진만)
+          required: false
+          schema:
+            type: string
+          examples:
+            studentApp:
+              value: "https://student-app-sigma-red.vercel.app/home"
+            surge:
+              value: "https://kmusds.surge.sh/home"
+            local:
+              value: "http://localhost:3000/docs"
+      responses:
+        "302":
+          description: Cognito Hosted UI로 리다이렉트 또는 기존 세션이 있으면 redirect 파라미터로 직접 리다이렉트
+        "400":
+          description: redirect 파라미터가 없거나 허용되지 않은 오리진
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "500":
+          description: 서버 내부 오류 (설정 누락 등)
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+
+  /auth/user/callback:
+    get:
+      summary: 사용자 Cognito 콜백
+      description: Cognito가 사용자 인증 후 Authorization Code와 state를 전달하는 엔드포인트. 서버는 코드 교환 후 `session` 쿠키를 설정하고 최초 요청된 redirect(허용된 사용자 오리진)로 302 리다이렉트합니다.
+      tags:
+        - Auth
+      security: []
+      parameters:
+        - name: code
+          in: query
+          description: Cognito에서 전달받은 Authorization Code
+          required: true
+          schema:
+            type: string
+        - name: state
+          in: query
+          description: CSRF 방지를 위한 state 값
+          required: true
+          schema:
+            type: string
+      responses:
+        "302":
+          description: 로그인 완료 후 최종 리다이렉트
+        "400":
+          description: state/code 오류 또는 redirect 누락/허용되지 않은 오리진
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "500":
+          description: 토큰 교환 실패 또는 서버 내부 오류
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+
+  /auth/user/logout:
+    get:
+      summary: 사용자 로그아웃
+      description: 사용자 세션을 삭제하고, 요청의 redirect 파라미터(절대 URL)가 허용된 사용자 오리진이며 Cognito에 사전 등록된 로그아웃 URL 목록에 존재하면 해당 URL로 최종 리다이렉트합니다.
+      tags:
+        - Auth
+      security: []
+      parameters:
+        - name: redirect
+          in: query
+          description: 로그아웃 완료 후 리다이렉트할 절대 URL (허용된 사용자 오리진 + Cognito 등록 URL)
+          required: false
+          schema:
+            type: string
+          examples:
+            studentApp:
+              value: "https://student-app-sigma-red.vercel.app/auth"
+            surge:
+              value: "https://kmusds.surge.sh/auth"
+            local:
+              value: "http://localhost:3000/auth"
+      responses:
+        "302":
+          description: 로그아웃 처리 후 최종 리다이렉트 또는 Cognito 로그아웃으로 리다이렉트
+        "400":
+          description: redirect 누락/허용되지 않은 오리진
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+
 components:
   securitySchemes:
     WebhookSecret:
@@ -954,7 +1164,7 @@ components:
       in: header
       name: X-Webhook-Secret
       description: 웹훅 인증을 위한 시크릿 키
-  
+
   schemas:
     Room:
       type: object

--- a/serverless.yml
+++ b/serverless.yml
@@ -70,16 +70,22 @@ provider:
     FCM_SERVICE_ACCOUNT_PATH: ${file(envs/config.${self:provider.stage}.json):FCM_SERVICE_ACCOUNT_PATH}
     FCM_PROJECT_ID: ${file(envs/config.${self:provider.stage}.json):FCM_PROJECT_ID}
     WEBHOOK_SECRET: ${file(envs/config.${self:provider.stage}.json):WEBHOOK_SECRET}
-    COGNITO_DOMAIN: ${file(envs/config.${self:provider.stage}.json):COGNITO_DOMAIN}
-    COGNITO_CLIENT_ID: ${file(envs/config.${self:provider.stage}.json):COGNITO_CLIENT_ID}
-    CALLBACK_URI: ${file(envs/config.${self:provider.stage}.json):CALLBACK_URI}
     COOKIE_SECURE: ${file(envs/config.${self:provider.stage}.json):COOKIE_SECURE}
     SESSION_TABLE: ${file(envs/config.${self:provider.stage}.json):SESSION_TABLE}
     SESSION_TTL_SECONDS: ${file(envs/config.${self:provider.stage}.json):SESSION_TTL_SECONDS, 173404800}
     SESSION_COOKIE_TTL_SECONDS: ${file(envs/config.${self:provider.stage}.json):SESSION_COOKIE_TTL_SECONDS, 900}
     PERSIST_COOKIE_TTL_SECONDS: ${file(envs/config.${self:provider.stage}.json):PERSIST_COOKIE_TTL_SECONDS, 172800000}
-    ALLOWED_REDIRECT_ORIGINS: ${file(envs/config.${self:provider.stage}.json):ALLOWED_REDIRECT_ORIGINS}
-    ALLOWED_LOGOUT_URLS: ${file(envs/config.${self:provider.stage}.json):ALLOWED_LOGOUT_URLS}
+    # Admin/User split auth configs
+    ADMIN_COGNITO_DOMAIN: ${file(envs/config.${self:provider.stage}.json):ADMIN_COGNITO_DOMAIN}
+    ADMIN_COGNITO_CLIENT_ID: ${file(envs/config.${self:provider.stage}.json):ADMIN_COGNITO_CLIENT_ID}
+    ADMIN_CALLBACK_URI: ${file(envs/config.${self:provider.stage}.json):ADMIN_CALLBACK_URI}
+    ADMIN_ALLOWED_REDIRECT_ORIGINS: ${file(envs/config.${self:provider.stage}.json):ADMIN_ALLOWED_REDIRECT_ORIGINS}
+    ADMIN_ALLOWED_LOGOUT_URLS: ${file(envs/config.${self:provider.stage}.json):ADMIN_ALLOWED_LOGOUT_URLS}
+    USER_COGNITO_DOMAIN: ${file(envs/config.${self:provider.stage}.json):USER_COGNITO_DOMAIN}
+    USER_COGNITO_CLIENT_ID: ${file(envs/config.${self:provider.stage}.json):USER_COGNITO_CLIENT_ID}
+    USER_CALLBACK_URI: ${file(envs/config.${self:provider.stage}.json):USER_CALLBACK_URI}
+    USER_ALLOWED_REDIRECT_ORIGINS: ${file(envs/config.${self:provider.stage}.json):USER_ALLOWED_REDIRECT_ORIGINS}
+    USER_ALLOWED_LOGOUT_URLS: ${file(envs/config.${self:provider.stage}.json):USER_ALLOWED_LOGOUT_URLS}
 
 layers:
   AppDependencies:
@@ -149,6 +155,66 @@ functions:
       - httpApi:
           method: get
           path: /auth/login
+
+  authAdminLogin:
+    name: ${self:provider.stage}-auth-admin-Login
+    handler: src.handlers.bff_auth_handler.admin_login
+    layers:
+      - { Ref: AppDependenciesLambdaLayer }
+    events:
+      - httpApi:
+          method: get
+          path: /auth/admin/login
+
+  authAdminCallback:
+    name: ${self:provider.stage}-auth-admin-Callback
+    handler: src.handlers.bff_auth_handler.admin_callback
+    layers:
+      - { Ref: AppDependenciesLambdaLayer }
+    events:
+      - httpApi:
+          method: get
+          path: /auth/admin/callback
+
+  authAdminLogout:
+    name: ${self:provider.stage}-auth-admin-Logout
+    handler: src.handlers.bff_auth_handler.admin_logout
+    layers:
+      - { Ref: AppDependenciesLambdaLayer }
+    events:
+      - httpApi:
+          method: get
+          path: /auth/admin/logout
+
+  authUserLogin:
+    name: ${self:provider.stage}-auth-user-Login
+    handler: src.handlers.bff_auth_handler.user_login
+    layers:
+      - { Ref: AppDependenciesLambdaLayer }
+    events:
+      - httpApi:
+          method: get
+          path: /auth/user/login
+
+  authUserCallback:
+    name: ${self:provider.stage}-auth-user-Callback
+    handler: src.handlers.bff_auth_handler.user_callback
+    layers:
+      - { Ref: AppDependenciesLambdaLayer }
+    events:
+      - httpApi:
+          method: get
+          path: /auth/user/callback
+
+  authUserLogout:
+    name: ${self:provider.stage}-auth-user-Logout
+    handler: src.handlers.bff_auth_handler.user_logout
+    layers:
+      - { Ref: AppDependenciesLambdaLayer }
+    events:
+      - httpApi:
+          method: get
+          path: /auth/user/logout
 
   bffProxy:
     name: ${self:provider.stage}-bff-Proxy

--- a/src/handlers/bff_auth_handler.py
+++ b/src/handlers/bff_auth_handler.py
@@ -399,3 +399,342 @@ def logout(event, context):
         "cookies": cookies_out,
         "body": "",
     }
+
+
+# =============================
+# Audience 분리 버전 (admin/user)
+# =============================
+
+
+def _cfg(aud: str) -> dict[str, object]:
+    aud_lc = (aud or "").lower()
+    if aud_lc == "admin":
+        domain = os.environ.get("ADMIN_COGNITO_DOMAIN", "").rstrip("/")
+        client_id = os.environ.get("ADMIN_COGNITO_CLIENT_ID", "")
+        callback = os.environ.get("ADMIN_CALLBACK_URI", "")
+        allowed_redirect_raw = os.environ.get("ADMIN_ALLOWED_REDIRECT_ORIGINS", "")
+        allowed_logout_raw = os.environ.get("ADMIN_ALLOWED_LOGOUT_URLS", "")
+    else:
+        domain = os.environ.get("USER_COGNITO_DOMAIN", "").rstrip("/")
+        client_id = os.environ.get("USER_COGNITO_CLIENT_ID", "")
+        callback = os.environ.get("USER_CALLBACK_URI", "")
+        allowed_redirect_raw = os.environ.get("USER_ALLOWED_REDIRECT_ORIGINS", "")
+        allowed_logout_raw = os.environ.get("USER_ALLOWED_LOGOUT_URLS", "")
+
+    allowed_redirect_origins: set[str] = set()
+    for item in _split_csv(allowed_redirect_raw):
+        origin = _parse_origin(item)
+        if origin:
+            allowed_redirect_origins.add(origin)
+    allowed_logout_urls: set[str] = set(_split_csv(allowed_logout_raw))
+
+    return {
+        "domain": domain,
+        "client_id": client_id,
+        "callback": callback,
+        "allowed_redirect_origins": allowed_redirect_origins,
+        "allowed_logout_urls": allowed_logout_urls,
+    }
+
+
+def _is_allowed_origin_for(url: str, allowed_redirect_origins: set[str]) -> bool:
+    if not _is_absolute_url(url):
+        return False
+    origin = _parse_origin(url)
+    if not origin:
+        return False
+    return origin in allowed_redirect_origins
+
+
+def _is_allowed_logout_url_for(url: str, allowed_logout_urls: set[str]) -> bool:
+    if not _is_absolute_url(url):
+        return False
+    return url in allowed_logout_urls
+
+
+def _login_with_aud(aud: str, event, context):
+    cfg = _cfg(aud)
+    domain = cfg["domain"] or ""
+    client_id = cfg["client_id"] or ""
+    callback = cfg["callback"] or ""
+    allowed_redirect_origins = cfg["allowed_redirect_origins"]  # type: ignore[assignment]
+
+    # 환경변수 검증
+    if not (domain and client_id and callback):
+        return {"statusCode": 500, "body": f"audience_{aud}_config_missing"}
+
+    # 1) 기존 세션 재사용 검증
+    headers_in = event.get("headers") or {}
+    cookie_header = headers_in.get("cookie") or headers_in.get("Cookie") or ""
+    cookies_array = event.get("cookies") or []
+    if isinstance(cookies_array, list) and cookies_array:
+        extra = "; ".join(cookies_array)
+        cookie_header = f"{cookie_header}; {extra}" if cookie_header else extra
+    cookie_map = _get_cookie_map(cookie_header)
+    existing_sid = cookie_map.get("session")
+
+    query_params = event.get("queryStringParameters") or {}
+    redirect_param = query_params.get("redirect")
+
+    if existing_sid:
+        session_data, validation_result = validate_session_security(
+            existing_sid, headers_in, event.get("requestContext", {}), audience=aud
+        )
+        if session_data and validation_result == "valid":
+            if redirect_param and _is_allowed_origin_for(
+                redirect_param, allowed_redirect_origins
+            ):
+                return {
+                    "statusCode": 302,
+                    "headers": {"Location": redirect_param},
+                    "body": "",
+                }
+            else:
+                return {"statusCode": 400, "body": "redirect_missing_or_not_allowed"}
+
+    # 2) PKCE 생성 및 state 세팅
+    code_verifier = _base64url_encode(os.urandom(32))
+    code_challenge = _base64url_encode(
+        hashlib.sha256(code_verifier.encode("utf-8")).digest()
+    )
+
+    set_cookie_headers: list[tuple[str, str]] = []
+    set_cookie_headers.append(
+        _set_cookie("cv", code_verifier, max_age=600, same_site="Lax")
+    )
+    state_nonce = _base64url_encode(secrets.token_bytes(16))
+    set_cookie_headers.append(
+        _set_cookie("st", urllib.parse.quote(state_nonce), max_age=600, same_site="Lax")
+    )
+    state_payload = {"s": state_nonce, "a": aud}
+    if redirect_param and _is_allowed_origin_for(
+        redirect_param, allowed_redirect_origins
+    ):
+        state_payload["r"] = redirect_param
+    state = _base64url_encode(json.dumps(state_payload).encode("utf-8"))
+
+    params = {
+        "client_id": client_id,
+        "redirect_uri": callback,
+        "response_type": "code",
+        "scope": "openid",
+        "code_challenge": code_challenge,
+        "code_challenge_method": "S256",
+        "state": state,
+    }
+    authorization_url = f"{domain}/oauth2/authorize?{urllib.parse.urlencode(params)}"
+
+    cookies_out = [v for _, v in set_cookie_headers]
+    headers_out: dict[str, object] = {"Location": authorization_url}
+    return {
+        "statusCode": 302,
+        "headers": headers_out,
+        "cookies": cookies_out,
+        "body": "",
+    }
+
+
+def _callback_with_aud(aud: str, event, context):
+    cfg = _cfg(aud)
+    domain = cfg["domain"] or ""
+    client_id = cfg["client_id"] or ""
+    callback = cfg["callback"] or ""
+    allowed_redirect_origins = cfg["allowed_redirect_origins"]  # type: ignore[assignment]
+
+    # 환경변수 검증
+    if not (domain and client_id and callback):
+        return {"statusCode": 500, "body": f"audience_{aud}_config_missing"}
+
+    query_params = event.get("queryStringParameters") or {}
+    code = query_params.get("code")
+    state_param = query_params.get("state") or ""
+
+    headers_in = event.get("headers") or {}
+    cookie_header = headers_in.get("cookie") or headers_in.get("Cookie") or ""
+    cookies_array = event.get("cookies") or []
+    if isinstance(cookies_array, list) and cookies_array:
+        extra = "; ".join(cookies_array)
+        cookie_header = f"{cookie_header}; {extra}" if cookie_header else extra
+    cookie_map = _get_cookie_map(cookie_header)
+    code_verifier = cookie_map.get("cv")
+    state_cookie = cookie_map.get("st")
+
+    if not state_param:
+        return {"statusCode": 400, "body": "Missing state"}
+    try:
+        padded = state_param + "=" * (-len(state_param) % 4)
+        payload = json.loads(
+            base64.urlsafe_b64decode(padded.encode("utf-8")).decode("utf-8")
+        )
+        state_nonce = payload.get("s")
+        if not (state_cookie and state_cookie == state_nonce):
+            return {"statusCode": 400, "body": "Invalid state"}
+        # audience 검증: state에 포함된 audience가 함수의 aud와 일치해야 함
+        state_audience = payload.get("a", "").lower()
+        if state_audience != aud.lower():
+            return {"statusCode": 400, "body": "Invalid audience"}
+    except Exception:
+        return {"statusCode": 400, "body": "Malformed state"}
+
+    if not code:
+        return {"statusCode": 400, "body": "Missing authorization code"}
+    if not code_verifier:
+        return {"statusCode": 400, "body": "Missing code_verifier"}
+
+    token_url = f"{domain}/oauth2/token"
+    form = {
+        "grant_type": "authorization_code",
+        "client_id": client_id,
+        "code": code,
+        "redirect_uri": callback,
+        "code_verifier": code_verifier,
+    }
+    data = urllib.parse.urlencode(form).encode("utf-8")
+    headers = {"Content-Type": "application/x-www-form-urlencoded"}
+    req = urllib.request.Request(token_url, data=data, headers=headers)
+
+    try:
+        with urllib.request.urlopen(req, timeout=10) as resp:
+            body = json.loads(resp.read().decode("utf-8"))
+    except urllib.error.HTTPError as e:
+        try:
+            err_text = (e.read() or b"").decode("utf-8")
+        except Exception:
+            err_text = ""
+        snippet = err_text[:256]
+        return {"statusCode": 500, "body": f"token_exchange_failed:{e.code}:{snippet}"}
+    except Exception:
+        return {"statusCode": 500, "body": "token_exchange_failed:unknown"}
+
+    access_token = body.get("access_token")
+    refresh_token = body.get("refresh_token")
+    expires_in = int(body.get("expires_in", 3600))
+    if not access_token:
+        return {"statusCode": 500, "body": "token_missing"}
+
+    sid = _base64url_encode(secrets.token_bytes(24))
+    ua = headers_in.get("user-agent", "")
+    ip = (event.get("requestContext") or {}).get("http", {}).get("sourceIp", "")
+    ua_hash = build_user_agent_ip_hash(ua, ip)
+
+    expires_at = int(time.time()) + expires_in
+    put_session(
+        sid,
+        access_token=access_token,
+        refresh_token=refresh_token,
+        expires_at=expires_at,
+        ua_hash=ua_hash,
+        ip=ip,
+        audience=aud,
+    )
+
+    set_cookie_headers: list[tuple[str, str]] = []
+    session_samesite = "None" if COOKIE_SECURE else "Lax"
+    set_cookie_headers.append(
+        _set_cookie(
+            "session",
+            sid,
+            max_age=SESSION_COOKIE_TTL_SECONDS,
+            same_site=session_samesite,
+        )
+    )
+    set_cookie_headers.append(
+        _set_cookie(
+            "ps", sid, max_age=PERSIST_COOKIE_TTL_SECONDS, same_site=session_samesite
+        )
+    )
+    set_cookie_headers.append(_set_cookie("cv", "", max_age=0))
+    set_cookie_headers.append(_set_cookie("st", "", max_age=0))
+
+    cookies_out = [v for _, v in set_cookie_headers]
+    r = payload.get("r") if isinstance(payload, dict) else None
+    if r and _is_allowed_origin_for(r, allowed_redirect_origins):
+        headers_out: dict[str, object] = {"Location": r}
+        return {
+            "statusCode": 302,
+            "headers": headers_out,
+            "cookies": cookies_out,
+            "body": "",
+        }
+    return {"statusCode": 400, "body": "redirect_missing_or_not_allowed"}
+
+
+def _logout_with_aud(aud: str, event, context):
+    cfg = _cfg(aud)
+    domain = cfg["domain"] or ""
+    client_id = cfg["client_id"] or ""
+    allowed_redirect_origins = cfg["allowed_redirect_origins"]  # type: ignore[assignment]
+    allowed_logout_urls = cfg["allowed_logout_urls"]  # type: ignore[assignment]
+
+    headers_in = event.get("headers") or {}
+    cookie_header = headers_in.get("cookie") or headers_in.get("Cookie") or ""
+    cookies_array = event.get("cookies") or []
+    if isinstance(cookies_array, list) and cookies_array:
+        extra = "; ".join(cookies_array)
+        cookie_header = f"{cookie_header}; {extra}" if cookie_header else extra
+    cookie_map = _get_cookie_map(cookie_header)
+    sid = cookie_map.get("session")
+    if sid:
+        delete_session(sid)
+
+    set_cookie_headers: list[tuple[str, str]] = []
+    for name in ["session", "ps", "cv", "st"]:
+        set_cookie_headers.append(_set_cookie(name, "", max_age=0))
+
+    query_params = event.get("queryStringParameters") or {}
+    requested_redirect = query_params.get("redirect")
+    logout_uri = None
+    if (
+        requested_redirect
+        and _is_allowed_origin_for(requested_redirect, allowed_redirect_origins)
+        and _is_allowed_logout_url_for(requested_redirect, allowed_logout_urls)
+    ):
+        logout_uri = requested_redirect
+
+    if not (domain and client_id):
+        cookies_out = [v for _, v in set_cookie_headers]
+        if not logout_uri:
+            return {"statusCode": 400, "body": "redirect_missing_or_not_allowed"}
+        return {
+            "statusCode": 302,
+            "headers": {"Location": logout_uri},
+            "cookies": cookies_out,
+            "body": "",
+        }
+
+    if not logout_uri:
+        return {"statusCode": 400, "body": "redirect_missing_or_not_allowed"}
+    params = {"client_id": client_id, "logout_uri": logout_uri}
+    location = f"{domain}/logout?{urllib.parse.urlencode(params)}"
+    cookies_out = [v for _, v in set_cookie_headers]
+    return {
+        "statusCode": 302,
+        "headers": {"Location": location},
+        "cookies": cookies_out,
+        "body": "",
+    }
+
+
+# 외부 노출 래퍼
+def admin_login(event, context):
+    return _login_with_aud("admin", event, context)
+
+
+def user_login(event, context):
+    return _login_with_aud("user", event, context)
+
+
+def admin_callback(event, context):
+    return _callback_with_aud("admin", event, context)
+
+
+def user_callback(event, context):
+    return _callback_with_aud("user", event, context)
+
+
+def admin_logout(event, context):
+    return _logout_with_aud("admin", event, context)
+
+
+def user_logout(event, context):
+    return _logout_with_aud("user", event, context)

--- a/src/utils/session_store.py
+++ b/src/utils/session_store.py
@@ -17,6 +17,10 @@ SESSION_TTL_SECONDS = int(
 )
 COGNITO_DOMAIN = os.environ.get("COGNITO_DOMAIN", "").rstrip("/")
 COGNITO_CLIENT_ID = os.environ.get("COGNITO_CLIENT_ID", "")
+ADMIN_COGNITO_DOMAIN = os.environ.get("ADMIN_COGNITO_DOMAIN", "").rstrip("/")
+ADMIN_COGNITO_CLIENT_ID = os.environ.get("ADMIN_COGNITO_CLIENT_ID", "")
+USER_COGNITO_DOMAIN = os.environ.get("USER_COGNITO_DOMAIN", "").rstrip("/")
+USER_COGNITO_CLIENT_ID = os.environ.get("USER_COGNITO_CLIENT_ID", "")
 
 
 _dynamodb = boto3.resource("dynamodb")
@@ -40,6 +44,7 @@ def put_session(
     expires_at: int,
     ua_hash: str,
     ip: str,
+    audience: Optional[str] = None,
 ) -> None:
     if not _table:
         raise RuntimeError("SESSION_TABLE not configured")
@@ -54,6 +59,8 @@ def put_session(
         "created_at": _now_epoch(),
         "ttl": ttl,
     }
+    if audience:
+        item["audience"] = audience
     _table.put_item(Item=item)
 
 
@@ -116,13 +123,61 @@ def refresh_access_token(
     return access_token, expires_in, new_refresh
 
 
+def _get_cfg_for_audience(audience: Optional[str]) -> Optional[Tuple[str, str]]:
+    aud = (audience or "").lower()
+    if aud == "admin":
+        domain = ADMIN_COGNITO_DOMAIN
+        client_id = ADMIN_COGNITO_CLIENT_ID
+    elif aud == "user":
+        domain = USER_COGNITO_DOMAIN
+        client_id = USER_COGNITO_CLIENT_ID
+    else:
+        # unknown audience → fallback to global if configured
+        domain = COGNITO_DOMAIN
+        client_id = COGNITO_CLIENT_ID
+    if not (domain and client_id):
+        return None
+    return domain, client_id
+
+
+def refresh_access_token_for(
+    audience: Optional[str], refresh_token: str
+) -> Optional[Tuple[str, int, Optional[str]]]:
+    cfg = _get_cfg_for_audience(audience)
+    if not cfg:
+        return None
+    domain, client_id = cfg
+    token_url = f"{domain}/oauth2/token"
+    form = {
+        "grant_type": "refresh_token",
+        "client_id": client_id,
+        "refresh_token": refresh_token,
+    }
+    data = urllib.parse.urlencode(form).encode("utf-8")
+    headers = {"Content-Type": "application/x-www-form-urlencoded"}
+    req = urllib.request.Request(token_url, data=data, headers=headers)
+    try:
+        with urllib.request.urlopen(req, timeout=10) as resp:
+            body = json.loads(resp.read().decode("utf-8"))
+    except Exception:
+        return None
+    access_token = body.get("access_token")
+    expires_in = int(body.get("expires_in", 3600))
+    new_refresh = body.get("refresh_token")
+    if not access_token:
+        return None
+    return access_token, expires_in, new_refresh
+
+
 def base64_encode(data: bytes) -> str:
     import base64
 
     return base64.b64encode(data).decode("utf-8")
 
 
-def validate_session_security(existing_sid, headers_in, request_context):
+def validate_session_security(
+    existing_sid, headers_in, request_context, audience: Optional[str] = None
+):
     """완전한 세션 보안 검증"""
 
     session_data = get_session(existing_sid)
@@ -164,8 +219,11 @@ def validate_session_security(existing_sid, headers_in, request_context):
     if expires_at - current_time < token_refresh_threshold:
         refresh_token = session_data.get("refresh_token")
         if refresh_token:
-
-            refresh_result = refresh_access_token(refresh_token)
+            # 세션에 기록된 audience가 있으면 우선 사용, 없으면 호출자 힌트 사용
+            effective_audience = session_data.get("audience") or audience
+            refresh_result = refresh_access_token_for(
+                effective_audience, refresh_token
+            ) or refresh_access_token(refresh_token)
 
             if refresh_result:
                 new_access_token, expires_in, new_refresh_token = refresh_result
@@ -179,6 +237,7 @@ def validate_session_security(existing_sid, headers_in, request_context):
                     expires_at=new_expires_at,
                     ua_hash=stored_ua_hash,  # 기존 해시 유지
                     ip=session_data.get("ip", ""),
+                    audience=effective_audience,
                 )
 
                 print(f"[login] Token refreshed successfully")


### PR DESCRIPTION
### 변경 사항 요약

#### 1. 관리자/학생 인증 분리 구현
   - 보안: 학생 계정으로 관리자 대시보드 접근 차단
   - 구조: Cognito 사용자 풀 분리 (dev-admin-pool, dev-user-pool)

#### 2. GitHub Secrets 관리 개선
   - Secrets 개수: 약 40개 → 7개로 감소
   - 관리 방식: **base64 인코딩**된 config JSON 사용

---

### 주요 변경 파일

#### 인증 핸들러 (`src/handlers/bff_auth_handler.py`)
- 새 엔드포인트: `/auth/admin/login`, `/auth/admin/callback`, `/auth/admin/logout`
- 새 엔드포인트: `/auth/user/login`, `/auth/user/callback`, `/auth/user/logout`
- **Audience (admin / user) 별 설정 로더** (`_cfg()`) 추가
- Audience별 화이트리스트 검증 로직 추가
- State에 audience 포함 및 콜백에서 검증 추가
- 환경변수 누락 시 에러 처리 추가

#### 세션 관리 (`src/utils/session_store.py`)
- `put_session()`에 `audience` 파라미터 추가
- `refresh_access_token_for()` 추가 (audience별 토큰 갱신)
- `validate_session_security()`에 audience 파라미터 추가
- 세션 갱신 시 audience 기반 설정 선택 로직

#### 서버리스 설정 (`serverless.yml`)
- 새로운 환경변수 매핑 추가 (ADMIN_*, USER_*)
- 6개 새 Lambda 함수 추가 (admin/user 로그인/콜백/로그아웃)

#### 배포 워크플로우 (`.github/workflows/deploy.yml`)
- Config 파일 생성 방식을 **base64 디코딩으로 전환**
- 긴 `echo` 명령어 제거, 간결한 디코딩 명령어로 대체

#### 환경 설정 파일
- `config.dev.json`: 관리자/학생 분리 설정 추가
- `config.local.json`: 로컬 테스트용 설정 정리
- 슬랙에서 받으시기 바랍니다.

#### OpenAPI 문서 (`docs/openapi.yml`)
- 새로운 인증 엔드포인트 문서화 추가

---

### 보안 개선 사항

#### Role-based 인증 분리
   - 관리자와 학생이 서로 다른 Cognito 풀 사용
   - Audience별 리다이렉트 화이트리스트 분리

---

### 마이그레이션 안내

기존 `/auth/login`, `/auth/callback`, `/auth/logout` 엔드포인트는 유지되나, 향후 단계적 제거 예정입니다. 모든 클라이언트가 새로운 엔드포인트로 전환될 때까지 병행 운영됩니다.