### PR TITLE
feat: 관리자 대시보드에 공지사항 필터링 및 검색 기능 적용

### DIFF
--- a/docs/openapi.yml
+++ b/docs/openapi.yml
@@ -368,6 +368,13 @@ paths:
             type: integer
             minimum: 1
             default: 1
+        - name: search
+          in: query
+          description: 검색어 (제목 또는 내용에서 검색)
+          required: false
+          schema:
+            type: string
+          example: "장학금"
       responses:
         "200":
           description: 성공적으로 필터링된 공지사항 목록을 반환했습니다.

--- a/docs/openapi.yml
+++ b/docs/openapi.yml
@@ -246,7 +246,9 @@ paths:
   /api/notices:
     get:
       summary: 공지사항 목록 조회 (페이지네이션)
-      description: 페이지네이션을 통해 공지사항 목록을 조회합니다. 페이지당 10개의 공지사항을 반환합니다.
+      description: |
+        페이지네이션을 통해 공지사항 목록을 조회합니다. 페이지당 10개의 공지사항을 반환합니다.
+        기본적으로 PUBLISHED 상태의 공지사항만 반환됩니다.
       tags:
         - Notices
       parameters:
@@ -265,9 +267,127 @@ paths:
           content:
             application/json:
               schema:
-                type: array
-                items:
-                  $ref: "#/components/schemas/Notice"
+                type: object
+                properties:
+                  notices:
+                    type: array
+                    items:
+                      $ref: "#/components/schemas/Notice"
+                  page_info:
+                    $ref: "#/components/schemas/PageInfo"
+        "500":
+          description: 서버 내부 오류
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+
+  /api/notices/filter:
+    get:
+      summary: 공지사항 필터링 및 정렬 조회
+      description: 다양한 조건으로 공지사항을 필터링하고 정렬하여 페이지네이션으로 조회합니다.
+      tags:
+        - Notices
+      parameters:
+        - name: status
+          in: query
+          description: |
+            공지사항 상태 (여러 개 선택 가능)
+            - 여러 개 선택 방법 1: 같은 파라미터를 여러 번 사용 (?status=DRAFT&status=SCHEDULED)
+            - 여러 개 선택 방법 2 (스웨거에서 불가): 쉼표로 구분 (?status=DRAFT,SCHEDULED)
+          required: false
+          schema:
+            type: array
+            items:
+              type: string
+              enum: [DRAFT, SCHEDULED, PUBLISHED]
+          style: form
+          explode: true
+          allowEmptyValue: false
+          examples:
+            single:
+              summary: 단일 상태
+              value: PUBLISHED
+            multiple_repeated:
+              summary: 여러 상태 (반복 파라미터)
+              value:
+                - DRAFT
+                - SCHEDULED
+        - name: is_important
+          in: query
+          description: 중요 공지 여부
+          required: false
+          schema:
+            type: boolean
+          example: true
+        - name: start_date
+          in: query
+          description: 검색 시작일 (YYYY-MM-DD)
+          required: false
+          schema:
+            type: string
+            format: date
+        - name: end_date
+          in: query
+          description: 검색 종료일 (YYYY-MM-DD)
+          required: false
+          schema:
+            type: string
+            format: date
+        - name: year
+          in: query
+          description: 특정 연도
+          required: false
+          schema:
+            type: integer
+        - name: month
+          in: query
+          description: 특정 월
+          required: false
+          schema:
+            type: integer
+        - name: day
+          in: query
+          description: 특정 일
+          required: false
+          schema:
+            type: integer
+        - name: sort
+          in: query
+          description: 정렬 순서
+          required: false
+          schema:
+            type: string
+            enum: [latest, oldest]
+            default: "latest"
+        - name: page
+          in: query
+          description: 페이지 번호
+          required: false
+          schema:
+            type: integer
+            minimum: 1
+            default: 1
+      responses:
+        "200":
+          description: 성공적으로 필터링된 공지사항 목록을 반환했습니다.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  notices:
+                    type: array
+                    items:
+                      $ref: "#/components/schemas/Notice"
+                  page_info:
+                    $ref: "#/components/schemas/PageInfo"
+        "400":
+          description: 잘못된 요청 (유효하지 않은 파라미터)
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
         "500":
           description: 서버 내부 오류
           content:
@@ -1090,6 +1210,11 @@ components:
           type: boolean
           description: 중요 공지 여부
           example: true
+        status:
+          type: string
+          description: 게시 상태
+          enum: [DRAFT, SCHEDULED, PUBLISHED]
+          example: "PUBLISHED"
 
     NoticeCreateRequest:
       type: object
@@ -1111,6 +1236,12 @@ components:
           description: 중요 공지 여부
           default: false
           example: true
+        status:
+          type: string
+          description: 게시 상태
+          enum: [DRAFT, SCHEDULED, PUBLISHED]
+          default: "PUBLISHED"
+          example: "PUBLISHED"
 
     Calendar:
       type: object
@@ -1197,6 +1328,23 @@ components:
           type: string
           description: 에러 메시지
           example: "Invalid request parameters"
+
+    PageInfo:
+      type: object
+      description: 페이지 정보
+      properties:
+        total_page:
+          type: integer
+          description: 전체 페이지 수
+          example: 10
+        total_notice:
+          type: integer
+          description: 전체 공지사항 수
+          example: 95
+        now_page:
+          type: integer
+          description: 현재 페이지 번호
+          example: 1
 
     Subscription:
       type: object

--- a/src/dto/__init__.py
+++ b/src/dto/__init__.py
@@ -8,6 +8,7 @@ from .notice_dto import (
     NoticeDeleteRequestDTO,
     NoticeUpdateRequestDTO,
     NoticeListWithPageInfoDTO,
+    NoticeFilterRequestDTO,
 )
 from .student_dto import (
     StudentDTO,
@@ -39,6 +40,7 @@ __all__ = [
     "NoticeDeleteRequestDTO",
     "NoticeUpdateRequestDTO",
     "NoticeListWithPageInfoDTO",
+    "NoticeFilterRequestDTO",
     "StudentDTO",
     "StudentListDTO",
     "StudentCreateRequestDTO",

--- a/src/dto/notice_dto.py
+++ b/src/dto/notice_dto.py
@@ -159,6 +159,7 @@ class NoticeFilterRequestDTO(BaseDTO):
     day: Optional[int] = None
     sort: str = "latest"
     page: int = 1
+    search: Optional[str] = None
 
     def validate(self) -> tuple[bool, Optional[str]]:
         """요청 데이터 검증"""

--- a/src/dto/notice_dto.py
+++ b/src/dto/notice_dto.py
@@ -2,7 +2,7 @@
 공지사항 관련 DTO 클래스들을 정의합니다.
 """
 
-from typing import Optional
+from typing import Optional, List
 from dataclasses import dataclass
 from .base_dto import BaseDTO
 
@@ -14,6 +14,7 @@ class NoticeCreateRequestDTO(BaseDTO):
     title: str
     content: str
     is_important: bool = False
+    status: str = "PUBLISHED"
 
     def validate(self) -> tuple[bool, Optional[str]]:
         """요청 데이터 검증"""
@@ -21,6 +22,8 @@ class NoticeCreateRequestDTO(BaseDTO):
             return False, "Title is required."
         if not self.content or not self.content.strip():
             return False, "Content is required."
+        if self.status not in ["DRAFT", "SCHEDULED", "PUBLISHED"]:
+            return False, "Status must be one of: DRAFT, SCHEDULED, PUBLISHED"
         return True, None
 
 
@@ -33,6 +36,7 @@ class NoticeDTO(BaseDTO):
     content: str
     date: str  # created_at → date 변환
     is_important: bool
+    status: str
 
     @classmethod
     def from_supabase_data(cls, data: dict) -> "NoticeDTO":
@@ -43,6 +47,7 @@ class NoticeDTO(BaseDTO):
             content=data["content"],
             date=data["created_at"],  # created_at → date 변환
             is_important=data["is_important"],
+            status=data.get("status", "PUBLISHED"),  # 기본값 처리
         )
 
 
@@ -122,6 +127,7 @@ class NoticeUpdateRequestDTO(BaseDTO):
     title: str
     content: str
     is_important: bool = False
+    status: Optional[str] = None
 
     def validate(self) -> tuple[bool, Optional[str]]:
         """요청 데이터 검증"""
@@ -131,4 +137,71 @@ class NoticeUpdateRequestDTO(BaseDTO):
             return False, "Title is required."
         if not self.content or not self.content.strip():
             return False, "Content is required."
+        if self.status is not None and self.status not in [
+            "DRAFT",
+            "SCHEDULED",
+            "PUBLISHED",
+        ]:
+            return False, "Status must be one of: DRAFT, SCHEDULED, PUBLISHED"
+        return True, None
+
+
+@dataclass
+class NoticeFilterRequestDTO(BaseDTO):
+    """공지사항 필터링 요청 DTO"""
+
+    status: Optional[List[str]] = None
+    is_important: Optional[bool] = None
+    start_date: Optional[str] = None
+    end_date: Optional[str] = None
+    year: Optional[int] = None
+    month: Optional[int] = None
+    day: Optional[int] = None
+    sort: str = "latest"
+    page: int = 1
+
+    def validate(self) -> tuple[bool, Optional[str]]:
+        """요청 데이터 검증"""
+        # status 검증
+        if self.status is not None:
+            valid_statuses = {"DRAFT", "SCHEDULED", "PUBLISHED"}
+            for s in self.status:
+                if s not in valid_statuses:
+                    return (
+                        False,
+                        f"Invalid status: {s}. Must be one of: DRAFT, SCHEDULED, PUBLISHED",
+                    )
+
+        # sort 검증
+        if self.sort not in ["latest", "oldest"]:
+            return False, "Sort must be 'latest' or 'oldest'"
+
+        # page 검증
+        if not isinstance(self.page, int) or self.page < 1:
+            return False, "Page must be a positive integer"
+
+        # 날짜 범위 검증
+        if self.start_date and self.end_date:
+            try:
+                from datetime import datetime
+
+                start = datetime.strptime(self.start_date, "%Y-%m-%d")
+                end = datetime.strptime(self.end_date, "%Y-%m-%d")
+                if start > end:
+                    return False, "start_date must be less than or equal to end_date"
+            except ValueError:
+                return False, "Date format must be YYYY-MM-DD"
+
+        # 단일 날짜 파라미터 검증
+        date_params = [self.year, self.month, self.day]
+        date_params_count = sum(1 for p in date_params if p is not None)
+        if date_params_count > 0 and date_params_count < 3:
+            return False, "year, month, and day must all be provided together"
+
+        if self.year is not None:
+            if not (1 <= self.month <= 12):
+                return False, "month must be between 1 and 12"
+            if not (1 <= self.day <= 31):
+                return False, "day must be between 1 and 31"
+
         return True, None

--- a/src/handlers/notices_handler.py
+++ b/src/handlers/notices_handler.py
@@ -9,6 +9,7 @@ from src.dto import (
     NoticeDeleteRequestDTO,
     NoticeUpdateRequestDTO,
     NoticeListWithPageInfoDTO,
+    NoticeFilterRequestDTO,
 )
 
 # 로거 설정
@@ -53,6 +54,7 @@ def create(event, context):
             title=body.get("title", ""),
             content=body.get("content", ""),
             is_important=body.get("is_important", False),
+            status=body.get("status", "PUBLISHED"),
         )
 
         # 요청 데이터 검증
@@ -62,7 +64,10 @@ def create(event, context):
 
         # 공지사항 생성
         notice_data, error = notices_service.create_notice(
-            request_dto.title, request_dto.content, request_dto.is_important
+            request_dto.title,
+            request_dto.content,
+            request_dto.is_important,
+            request_dto.status,
         )
 
         if error:
@@ -176,6 +181,7 @@ def update(event, context):
             title=body.get("title", ""),
             content=body.get("content", ""),
             is_important=body.get("is_important", False),
+            status=body.get("status"),
         )
 
         # 요청 데이터 검증
@@ -189,6 +195,7 @@ def update(event, context):
             request_dto.title,
             request_dto.content,
             request_dto.is_important,
+            request_dto.status,
         )
 
         if error:
@@ -204,4 +211,160 @@ def update(event, context):
         return responses.create_error_response("Invalid JSON format.", 400)
     except Exception as e:
         logger.error(f"❌ 공지사항 수정 실패: {e}")
+        return responses.create_error_response("Internal server error.", 500)
+
+
+def filter(event, context):
+    """
+    GET /notices/filter API 요청을 처리하는 핸들러 (필터링 및 정렬)
+    """
+    logger.info("✅ Processing filter notices request")
+
+    try:
+        # 쿼리 파라미터 추출
+        query_params = event.get("queryStringParameters") or {}
+        multi_params = event.get("multiValueQueryStringParameters") or {}
+
+        # 디버깅용 로깅
+        logger.info(f"queryStringParameters: {query_params}")
+        logger.info(f"multiValueQueryStringParameters: {multi_params}")
+
+        # status 파라미터 추출 (여러 개 선택 가능)
+        status = None
+
+        # 1순위: multiValueQueryStringParameters 확인 (HTTP API v2에서는 없을 수 있음)
+        if multi_params and "status" in multi_params:
+            status_list = multi_params.get("status", [])
+            if isinstance(status_list, list) and len(status_list) > 0:
+                status = status_list
+                logger.info(f"Status from multiValueQueryStringParameters: {status}")
+
+        # 2순위: queryStringParameters에서 리스트인 경우
+        if status is None and "status" in query_params:
+            status_value = query_params.get("status")
+            if isinstance(status_value, list):
+                status = status_value
+                logger.info(f"Status from queryStringParameters (list): {status}")
+            elif isinstance(status_value, str):
+                # 쉼표로 구분된 문자열 처리 (예: "DRAFT,SCHEDULED")
+                if "," in status_value:
+                    status = [s.strip() for s in status_value.split(",") if s.strip()]
+                    logger.info(
+                        f"Status from queryStringParameters (comma-separated): {status}"
+                    )
+                else:
+                    status = [status_value]
+                    logger.info(f"Status from queryStringParameters (single): {status}")
+
+        # 3순위: rawQueryString에서 직접 파싱 (fallback)
+        if status is None:
+            raw_query = event.get("rawQueryString", "")
+            if raw_query and "status=" in raw_query:
+                # rawQueryString에서 status 파라미터 추출
+                import urllib.parse
+
+                parsed = urllib.parse.parse_qs(raw_query)
+                if "status" in parsed:
+                    status = parsed["status"]
+                    logger.info(f"Status from rawQueryString: {status}")
+
+        # 빈 리스트나 빈 문자열 제거
+        if status:
+            status = [s for s in status if s and s.strip()]
+            if len(status) == 0:
+                status = None
+
+        # is_important 파싱 (문자열 "true"/"false"를 boolean으로 변환)
+        is_important = None
+        if "is_important" in query_params:
+            is_important_str = query_params.get("is_important")
+            if is_important_str.lower() == "true":
+                is_important = True
+            elif is_important_str.lower() == "false":
+                is_important = False
+
+        # 날짜 파라미터 추출
+        start_date = query_params.get("start_date")
+        end_date = query_params.get("end_date")
+
+        # 단일 날짜 파라미터 추출 및 변환
+        year = None
+        month = None
+        day = None
+        if "year" in query_params:
+            try:
+                year = int(query_params.get("year"))
+            except (ValueError, TypeError):
+                return responses.create_error_response("Invalid year format.", 400)
+        if "month" in query_params:
+            try:
+                month = int(query_params.get("month"))
+            except (ValueError, TypeError):
+                return responses.create_error_response("Invalid month format.", 400)
+        if "day" in query_params:
+            try:
+                day = int(query_params.get("day"))
+            except (ValueError, TypeError):
+                return responses.create_error_response("Invalid day format.", 400)
+
+        # 정렬 파라미터 (기본값: latest)
+        sort = query_params.get("sort", "latest")
+
+        # 페이지 파라미터 추출 및 변환
+        page_str = query_params.get("page", "1")
+        try:
+            page = int(page_str)
+            if page < 1:
+                return responses.create_error_response(
+                    "Page number must be greater than 0.", 400
+                )
+        except ValueError:
+            return responses.create_error_response("Invalid page number format.", 400)
+
+        # DTO 생성 및 검증
+        filter_dto = NoticeFilterRequestDTO(
+            status=status,
+            is_important=is_important,
+            start_date=start_date,
+            end_date=end_date,
+            year=year,
+            month=month,
+            day=day,
+            sort=sort,
+            page=page,
+        )
+
+        is_valid, error_message = filter_dto.validate()
+        if not is_valid:
+            return responses.create_error_response(error_message, 400)
+
+        # 필터링된 공지사항 조회
+        notices_data, total_count, page_size, error = (
+            notices_service.get_notices_with_filters(
+                status=filter_dto.status,
+                is_important=filter_dto.is_important,
+                start_date=filter_dto.start_date,
+                end_date=filter_dto.end_date,
+                year=filter_dto.year,
+                month=filter_dto.month,
+                day=filter_dto.day,
+                sort=filter_dto.sort,
+                page=filter_dto.page,
+            )
+        )
+
+        if error:
+            return responses.create_error_response(error, 500)
+
+        # DTO를 사용하여 응답 데이터 변환 (페이지 정보 포함)
+        notice_list_with_page_info_dto = NoticeListWithPageInfoDTO.from_supabase_data(
+            notices_data, total_count, page, page_size
+        )
+
+        return responses.create_success_response(
+            notice_list_with_page_info_dto.to_dict()
+        )
+
+    except Exception as e:
+        logger.error(f"❌ 필터링 공지사항 조회 실패: {e}")
         return responses.create_error_response("Internal server error.", 500)

--- a/src/handlers/notices_handler.py
+++ b/src/handlers/notices_handler.py
@@ -321,6 +321,9 @@ def filter(event, context):
         except ValueError:
             return responses.create_error_response("Invalid page number format.", 400)
 
+        # 검색어 파라미터 추출
+        search_term = query_params.get("search")
+
         # DTO 생성 및 검증
         filter_dto = NoticeFilterRequestDTO(
             status=status,
@@ -332,6 +335,7 @@ def filter(event, context):
             day=day,
             sort=sort,
             page=page,
+            search=search_term,
         )
 
         is_valid, error_message = filter_dto.validate()
@@ -350,6 +354,7 @@ def filter(event, context):
                 day=filter_dto.day,
                 sort=filter_dto.sort,
                 page=filter_dto.page,
+                search=filter_dto.search,
             )
         )
 

--- a/src/services/notices_service.py
+++ b/src/services/notices_service.py
@@ -1,4 +1,6 @@
 import logging
+from typing import Optional, List
+from datetime import datetime, date
 from src.utils.supabase_client import get_supabase_client
 
 # 로거 설정
@@ -20,7 +22,7 @@ def get_notice_by_id(notice_id: str):
         response = (
             supabase.postgrest.schema("core")
             .from_("notice")
-            .select("id, title, content, created_at, is_important")
+            .select("id, title, content, created_at, is_important, status")
             .eq("id", notice_id)
             .execute()
         )
@@ -41,7 +43,9 @@ def get_notice_by_id(notice_id: str):
         return None, error_message
 
 
-def create_notice(title: str, content: str, is_important: bool = False):
+def create_notice(
+    title: str, content: str, is_important: bool = False, status: str = "PUBLISHED"
+):
     """
     Supabase 클라이언트를 사용하여 새로운 공지사항을 생성합니다.
     """
@@ -53,7 +57,12 @@ def create_notice(title: str, content: str, is_important: bool = False):
         logger.info("새 공지사항 생성 시작")
 
         # 공지사항 데이터 준비
-        notice_data = {"title": title, "content": content, "is_important": is_important}
+        notice_data = {
+            "title": title,
+            "content": content,
+            "is_important": is_important,
+            "status": status,
+        }
 
         response = (
             supabase.postgrest.schema("core")
@@ -105,7 +114,10 @@ def get_notices_with_pagination(page: int = 1):
         response = (
             supabase.postgrest.schema("core")
             .from_("notice")
-            .select("id, title, content, created_at, is_important", count="exact")
+            .select(
+                "id, title, content, created_at, is_important, status", count="exact"
+            )
+            .eq("status", "PUBLISHED")
             .order("created_at", desc=True)
             .range(offset, offset + PAGE_SIZE - 1)
             .execute()
@@ -184,7 +196,11 @@ def delete_notice_by_id(notice_id: int):
 
 
 def update_notice_by_id(
-    notice_id: int, title: str, content: str, is_important: bool = False
+    notice_id: int,
+    title: str,
+    content: str,
+    is_important: bool = False,
+    status: Optional[str] = None,
 ):
     """
     Supabase 클라이언트를 사용하여 특정 공지사항을 수정합니다.
@@ -198,6 +214,8 @@ def update_notice_by_id(
 
         # 수정할 데이터 준비
         update_data = {"title": title, "content": content, "is_important": is_important}
+        if status is not None:
+            update_data["status"] = status
 
         response = (
             supabase.postgrest.schema("core")
@@ -222,3 +240,97 @@ def update_notice_by_id(
         logger.error(f"❌ Supabase API 호출 실패: {e}")
         error_message = getattr(e, "message", str(e))
         return None, error_message
+
+
+def get_notices_with_filters(
+    status: Optional[List[str]] = None,
+    is_important: Optional[bool] = None,
+    start_date: Optional[str] = None,
+    end_date: Optional[str] = None,
+    year: Optional[int] = None,
+    month: Optional[int] = None,
+    day: Optional[int] = None,
+    sort: str = "latest",
+    page: int = 1,
+):
+    """
+    Supabase 클라이언트를 사용하여 필터링된 공지사항을 가져옵니다.
+    페이지당 10개의 공지사항을 반환합니다.
+
+    Returns:
+        tuple: (notices_data, total_count, page_size, error)
+    """
+    PAGE_SIZE = 10
+
+    try:
+        supabase = get_supabase_client("core")
+        if not supabase:
+            return None, None, None, "Supabase client could not be initialized."
+
+        logger.info(
+            f"Supabase 'notice' 테이블 필터링 조회 시작 - 페이지: {page}, 크기: {PAGE_SIZE}"
+        )
+
+        # 페이지네이션 계산
+        offset = (page - 1) * PAGE_SIZE
+
+        # 쿼리 빌더 시작
+        query = (
+            supabase.postgrest.schema("core")
+            .from_("notice")
+            .select(
+                "id, title, content, created_at, is_important, status", count="exact"
+            )
+        )
+
+        # status 필터링 (여러 개 선택 가능, OR 조건)
+        if status is not None and len(status) > 0:
+            query = query.in_("status", status)
+            logger.info(f"Status 필터 적용: {status}")
+
+        # is_important 필터링
+        if is_important is not None:
+            query = query.eq("is_important", is_important)
+            logger.info(f"Is_important 필터 적용: {is_important}")
+
+        # 날짜 필터링
+        if start_date and end_date:
+            # 범위 필터링
+            query = query.gte("created_at", start_date).lte("created_at", end_date)
+            logger.info(f"날짜 범위 필터 적용: {start_date} ~ {end_date}")
+        elif year is not None and month is not None and day is not None:
+            # 단일 날짜 필터링 (해당 날짜의 00:00:00 ~ 23:59:59)
+            single_date_start = f"{year:04d}-{month:02d}-{day:02d}T00:00:00"
+            single_date_end = f"{year:04d}-{month:02d}-{day:02d}T23:59:59"
+            query = query.gte("created_at", single_date_start).lte(
+                "created_at", single_date_end
+            )
+            logger.info(f"단일 날짜 필터 적용: {year}-{month:02d}-{day:02d}")
+
+        # 정렬
+        if sort == "oldest":
+            query = query.order("created_at", desc=False)
+            logger.info("정렬: 오래된순 (created_at ASC)")
+        else:
+            query = query.order("created_at", desc=True)
+            logger.info("정렬: 최신순 (created_at DESC)")
+
+        # 페이지네이션 적용
+        query = query.range(offset, offset + PAGE_SIZE - 1)
+
+        # 쿼리 실행
+        response = query.execute()
+
+        notices_data = response.data
+        total_count = response.count if response.count is not None else 0
+        logger.info(
+            f"✅ Supabase로부터 필터링된 페이지 {page}의 {len(notices_data)}개 공지사항을 성공적으로 가져왔습니다. (전체: {total_count}개)"
+        )
+
+        # 원시 데이터와 페이지 크기 정보를 반환 (DTO 변환은 핸들러에서 처리)
+        return notices_data, total_count, PAGE_SIZE, None
+
+    except Exception as e:
+        logger.error(f"❌ Supabase API 호출 실패: {e}")
+        error_message = getattr(e, "message", str(e))
+        return None, None, None, error_message

--- a/src/services/notices_service.py
+++ b/src/services/notices_service.py
@@ -252,9 +252,10 @@ def get_notices_with_filters(
     day: Optional[int] = None,
     sort: str = "latest",
     page: int = 1,
+    search: Optional[str] = None,
 ):
     """
-    Supabase 클라이언트를 사용하여 필터링된 공지사항을 가져옵니다.
+    Supabase 클라이언트를 사용하여 필터링 및 검색된 공지사항을 가져옵니다.
     페이지당 10개의 공지사항을 반환합니다.
 
     Returns:
@@ -282,6 +283,15 @@ def get_notices_with_filters(
                 "id, title, content, created_at, is_important, status", count="exact"
             )
         )
+
+        # 검색 필터링 (title 또는 content에 검색어 포함)
+        if search:
+            # ILIKE를 사용한 부분 문자열 검색 (대소문자 무시)
+            search_pattern = f"%{search}%"
+            query = query.or_(
+                f"title.ilike.{search_pattern},content.ilike.{search_pattern}"
+            )
+            logger.info(f"검색어 적용: {search}")
 
         # status 필터링 (여러 개 선택 가능, OR 조건)
         if status is not None and len(status) > 0:

--- a/src/utils/routing.py
+++ b/src/utils/routing.py
@@ -29,6 +29,7 @@ ROUTE_OVERRIDES: Dict[Tuple[str, str], Tuple[str, str]] = {
         "notifications_handler",
         "send_notification_handler",
     ),
+    ("GET", "notices/filter"): ("notices_handler", "filter"),
 }
 
 # 3) 기본 함수 규칙: (METHOD, resource) → function name


### PR DESCRIPTION
### 🔖 개요

공지사항을 다양한 조건으로 **필터링하고 검색할 수 있는 기능**을 추가하여 사용 편의성을 개선했습니다.

### 📝 주요 변경 사항

- **신규 API 엔드포인트 추가: GET /api/notices/filter**
  - 다양한 쿼리 파라미터를 조합하여 공지사항을 필터링, 정렬, 검색 
및 페이지네이션 할 수 있는 API를 구현했습니다.

- **필터링 및 검색 기능**:
  - 상태 필터링: status (e.g., DRAFT, PUBLISHED) - 다중 선택 가능
  - 중요도 필터링: is_important (true/false)
  - 날짜 필터링:
    - 특정 기간: start_date, end_date
    - 특정 날짜: year, month, day
  - 키워드 검색: search (제목 및 내용 대상, 대소문자 무관)
  - 정렬 기능:
    - sort (latest: 최신순, oldest: 오래된순)

- **DTO 추가**:
  - NoticeFilterRequestDTO를 추가하여 필터링 관련 요청 파라미터를 효과적으로 처리하고 유효성을 검증합니다.

- **핸들러 및 서비스 로직 구현**:
  - `notices_handler.py`: filter 핸들러를 추가하여 API 요청을 받아 처리합니다.
  - `notices_service.py`: `get_notices_with_filters` 서비스를 추가하여 Supabase 쿼리를 동적으로 생성하고 실행합니다.

- **Swagger 문서 업데이트**:
  - `docs/openapi.yml`: 신규 API(GET /api/notices/filter)에 대한 명세를 상세히 추가했습니다.

### 🔗 API 변경 사항

  `GET /api/notices/filter`

   - 설명: 다양한 조건으로 공지사항을 필터링하고 정렬하여 
     페이지네이션으로 조회합니다.
   - 쿼리 파라미터:
     - status: string[] (공지사항 상태, 다중 선택 가능)
     - is_important: boolean (중요 공지 여부)
     - start_date: string (검색 시작일, YYYY-MM-DD)
     - end_date: string (검색 종료일, YYYY-MM-DD)
     - year: integer (특정 연도)
     - month: integer (특정 월)
     - day: integer (특정 일)
     - sort: string (정렬 순서: latest, oldest)
     - page: integer (페이지 번호)
     - search: string (검색어)