### PR TITLE
fix: 세션 검증 시 IP 주소를 제외하고 브라우저 정보 (User Agent) 만 확인하도록 수정

### DIFF
--- a/src/handlers/bff_auth_handler.py
+++ b/src/handlers/bff_auth_handler.py
@@ -12,7 +12,7 @@ from typing import Dict
 from src.utils.session_store import (
     put_session,
     delete_session,
-    build_user_agent_ip_hash,
+    build_user_agent_hash,
     validate_session_security,
 )
 
@@ -298,8 +298,8 @@ def callback(event, context):
     sid = _base64url_encode(secrets.token_bytes(24))
 
     ua = headers_in.get("user-agent", "")
-    ip = (event.get("requestContext") or {}).get("http", {}).get("sourceIp", "")
-    ua_hash = build_user_agent_ip_hash(ua, ip)
+    # ip = (event.get("requestContext") or {}).get("http", {}).get("sourceIp", "")
+    ua_hash = build_user_agent_hash(ua)
 
     expires_at = int(time.time()) + expires_in
     put_session(
@@ -308,7 +308,7 @@ def callback(event, context):
         refresh_token=refresh_token,
         expires_at=expires_at,
         ua_hash=ua_hash,
-        ip=ip,
+        # ip=ip,
     )
 
     set_cookie_headers: list[tuple[str, str]] = []

--- a/src/handlers/bff_handler.py
+++ b/src/handlers/bff_handler.py
@@ -11,7 +11,7 @@ from src.utils.session_store import (
     get_session,
     refresh_access_token,
     put_session,
-    build_user_agent_ip_hash,
+    build_user_agent_hash,
 )
 from src.utils.routing import resolve_handler
 from src.utils.cognito_auth import get_cognito_groups, get_user_info
@@ -119,10 +119,10 @@ def proxy(event, context):
     if not session:
         return _build_response(401, {"message": "Session not found"})
 
-    # UA/IP 바인딩 확인
+    # UA 바인딩 확인
     ua = headers_in.get("user-agent", "")
-    ip = (event.get("requestContext") or {}).get("http", {}).get("sourceIp", "")
-    if session.get("ua_hash") != build_user_agent_ip_hash(ua, ip):
+    # ip = (event.get("requestContext") or {}).get("http", {}).get("sourceIp", "")
+    if session.get("ua_hash") != build_user_agent_hash(ua):
         return _build_response(401, {"message": "Session bind mismatch"})
 
     # 만료 직후 refresh
@@ -157,7 +157,7 @@ def proxy(event, context):
                 refresh_token=session.get("refresh_token"),
                 expires_at=session["expires_at"],
                 ua_hash=session["ua_hash"],
-                ip=session.get("ip", ""),
+                # ip=session.get("ip", ""),
             )
             # 세션 쿠키 재발급(슬라이딩 윈도우)
             cookies_out.append(

--- a/src/utils/session_store.py
+++ b/src/utils/session_store.py
@@ -28,7 +28,9 @@ def _now_epoch() -> int:
 
 
 def build_user_agent_ip_hash(user_agent: str, ip: str) -> str:
-    base = (user_agent or "") + "|" + (ip or "")
+    # IP 주소는 모바일 환경 등에서 자주 바뀌므로 세션 해시에서 제외합니다.
+    # User-Agent만 검증하여 동일 브라우저에서 요청이 왔는지 확인합니다.
+    base = user_agent or ""
     return hashlib.sha256(base.encode("utf-8")).hexdigest()
 
 

--- a/src/utils/session_store.py
+++ b/src/utils/session_store.py
@@ -27,7 +27,7 @@ def _now_epoch() -> int:
     return int(time.time())
 
 
-def build_user_agent_ip_hash(user_agent: str, ip: str) -> str:
+def build_user_agent_hash(user_agent: str) -> str:
     # IP 주소는 모바일 환경 등에서 자주 바뀌므로 세션 해시에서 제외합니다.
     # User-Agent만 검증하여 동일 브라우저에서 요청이 왔는지 확인합니다.
     base = user_agent or ""
@@ -41,7 +41,7 @@ def put_session(
     refresh_token: Optional[str],
     expires_at: int,
     ua_hash: str,
-    ip: str,
+    # ip: str,
 ) -> None:
     if not _table:
         raise RuntimeError("SESSION_TABLE not configured")
@@ -52,7 +52,7 @@ def put_session(
         "refresh_token": refresh_token or "",
         "expires_at": int(expires_at),
         "ua_hash": ua_hash,
-        "ip": ip,
+        # "ip": ip,
         "created_at": _now_epoch(),
         "ttl": ttl,
     }
@@ -133,7 +133,7 @@ def validate_session_security(existing_sid, headers_in, request_context):
         return None, "session_not_found_in_db"
 
     # 2. 세션 데이터 무결성 검증
-    required_fields = ["access_token", "expires_at", "ua_hash", "ip", "created_at"]
+    required_fields = ["access_token", "expires_at", "ua_hash", "created_at"]
     for field in required_fields:
         if field not in session_data or not session_data[field]:
             return None, f"session_data_corrupted_missing_{field}"
@@ -147,10 +147,9 @@ def validate_session_security(existing_sid, headers_in, request_context):
         delete_session(existing_sid)
         return None, "session_expired"
 
-    # 4. User-Agent + IP 해시 검증 (세션 하이재킹 방지)
+    # 4. User-Agent 해시 검증 (세션 하이재킹 방지)
     ua = headers_in.get("user-agent", "")
-    ip = request_context.get("http", {}).get("sourceIp", "")
-    current_ua_hash = build_user_agent_ip_hash(ua, ip)
+    current_ua_hash = build_user_agent_hash(ua)
     stored_ua_hash = session_data.get("ua_hash", "")
 
     if stored_ua_hash != current_ua_hash:
@@ -179,7 +178,7 @@ def validate_session_security(existing_sid, headers_in, request_context):
                     refresh_token=new_refresh_token or refresh_token,
                     expires_at=new_expires_at,
                     ua_hash=stored_ua_hash,  # 기존 해시 유지
-                    ip=session_data.get("ip", ""),
+                    # ip=session_data.get("ip", ""),
                 )
 
                 print(f"[login] Token refreshed successfully")


### PR DESCRIPTION
### UA/IP 검증 완화

- 현재 세션 검증코드에서는 UA와 IP를 모두 검사하고 있다

```python
def build_user_agent_ip_hash(user_agent: str, ip: str) -> str:
    base = (user_agent or "") + "|" + (ip or "")
    return hashlib.sha256(base.encode("utf-8")).hexdigest()
    
def validate_session_security(existing_sid, headers_in, request_context):
		...
		# 4. User-Agent + IP 해시 검증 (세션 하이재킹 방지)
    ua = headers_in.get("user-agent", "")
    ip = request_context.get("http", {}).get("sourceIp", "")
    current_ua_hash = build_user_agent_ip_hash(ua, ip)
    stored_ua_hash = session_data.get("ua_hash", "")

    if stored_ua_hash != current_ua_hash:
        print(
            f"[security] Session hijacking detected! stored_hash={stored_ua_hash[:8]}... current_hash={current_ua_hash[:8]}..."
        )
        # 하이재킹 감지 시 즉시 세션 삭제
        delete_session(existing_sid)
        return None, "session_hijacking_detected"
```

- 현재 코드는 사용자가 처음 로그인할 때 **브라우저 정보(User-Agent)**와 **IP 주소**를 합쳐서 **`ua_hash`** 를 생성하고 세션 정보와 함께 DynamoDB에 저장한다.
- 이후 사용자가 API를 요청할 때 동일한 방식으로 `ua_hash` 를 생성하여 DB에 저장된 값과 비교하는데, 이때 값이 다르면 **세션이 탈취되었다고 간주하고 삭제**한다.

→ IP가 자주 변한다는 점을 고려하여 **브라우저 정보만 고려하기로** 결정. IP 주소 검증은 제외.