### PR TITLE
feat: FCM 알림 시스템 개선 및 개인 알림 기능 추가

### DIFF
--- a/docs/openapi.yml
+++ b/docs/openapi.yml
@@ -732,7 +732,9 @@ paths:
   /api/subscriptions:
     post:
       summary: FCM 구독 생성
-      description: FCM 토큰을 등록하여 푸시 알림을 받을 수 있도록 구독합니다.
+      description: |
+        FCM 토큰을 등록하여 푸시 알림을 받을 수 있도록 구독합니다.
+        학번(student_no)은 로그인된 사용자 세션에서 자동으로 추출됩니다.
       tags:
         - Notifications
       requestBody:
@@ -743,8 +745,7 @@ paths:
               $ref: "#/components/schemas/SubscriptionCreateRequest"
             example:
               fcm_token: "fcm_token_example_12345"
-              student_no: "20243105"
-              platform: "ios"
+              platform: "web"
       responses:
         "200":
           description: 구독이 성공적으로 생성되었습니다.
@@ -754,6 +755,12 @@ paths:
                 $ref: "#/components/schemas/Subscription"
         "400":
           description: 잘못된 요청 (필수 필드 누락 또는 형식 오류)
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "401":
+          description: 인증 실패 (로그인 필요)
           content:
             application/json:
               schema:
@@ -830,6 +837,42 @@ paths:
                 $ref: "#/components/schemas/NotificationResult"
         "400":
           description: 잘못된 요청 (필수 필드 누락)
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "500":
+          description: 서버 내부 오류
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+
+  /api/notifications/individual:
+    post:
+      summary: 개인 알림 발송
+      description: 특정 학생에게 개인 알림을 발송합니다. 학생이 여러 기기를 가진 경우 모든 활성 기기로 발송됩니다.
+      tags:
+        - Notifications
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/PersonalNotificationRequest"
+            example:
+              student_no: "20243105"
+              title: "개인 알림"
+              content: "청구서 확인 부탁드립니다."
+      responses:
+        "200":
+          description: 알림이 성공적으로 발송되었습니다.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PersonalNotificationResult"
+        "400":
+          description: 잘못된 요청 (필수 필드 누락 또는 형식 오류)
           content:
             application/json:
               schema:
@@ -1390,22 +1433,20 @@ components:
 
     SubscriptionCreateRequest:
       type: object
-      description: FCM 구독 생성 요청
+      description: |
+        FCM 구독 생성 요청
+        학번(student_no)은 로그인된 사용자 세션에서 자동으로 추출되므로 요청에 포함하지 않습니다.
       required:
         - fcm_token
-        - student_no
       properties:
         fcm_token:
           type: string
           description: FCM 토큰
           example: "fcm_token_example_12345"
-        student_no:
-          type: string
-          description: 학번
-          example: "20192762"
         platform:
           type: string
           description: 플랫폼 (기본값 web)
+          enum: [web, android, ios]
           default: "web"
           example: "web"
 
@@ -1599,6 +1640,72 @@ components:
           type: integer
           description: 파일 크기 (bytes)
           example: 2132
+
+    PersonalNotificationRequest:
+      type: object
+      description: 개인 알림 발송 요청
+      required:
+        - student_no
+        - title
+        - content
+      properties:
+        student_no:
+          type: string
+          description: 학번
+          example: "20243105"
+        title:
+          type: string
+          description: 알림 제목
+          example: "개인 알림"
+        content:
+          type: string
+          description: 알림 내용
+          example: "청구서 확인 부탁드립니다."
+
+    PersonalNotificationResult:
+      type: object
+      description: 개인 알림 발송 결과
+      properties:
+        success:
+          type: boolean
+          description: 발송 성공 여부
+          example: true
+        personal_notification_id:
+          type: integer
+          description: 개인 알림 ID
+          example: 123
+        student_no:
+          type: string
+          description: 학번
+          example: "20243105"
+        total_devices:
+          type: integer
+          description: 학생의 전체 기기 수
+          example: 3
+        success_count:
+          type: integer
+          description: 성공한 발송 수
+          example: 2
+        failure_count:
+          type: integer
+          description: 실패한 발송 수
+          example: 1
+        invalid_tokens:
+          type: array
+          items:
+            type: string
+          description: 무효한 토큰 리스트
+          example: ["token1"]
+        failed_tokens:
+          type: array
+          items:
+            type: string
+          description: 실패한 토큰 리스트
+          example: []
+        message:
+          type: string
+          description: 추가 메시지 (구독 없는 경우)
+          example: "No active subscriptions found for this student"
 
 tags:
   - name: Rooms

--- a/src/dto/notification_dto.py
+++ b/src/dto/notification_dto.py
@@ -38,16 +38,12 @@ class SubscriptionCreateRequestDTO(BaseDTO):
     """FCM 구독 생성 요청 DTO"""
 
     fcm_token: str
-    student_no: str
     platform: str = "web"
 
     def validate(self) -> tuple[bool, Optional[str]]:
         """요청 데이터 검증"""
         if not self.fcm_token or not self.fcm_token.strip():
             return False, "fcm_token is required"
-
-        if not self.student_no or not self.student_no.strip():
-            return False, "student_no is required"
 
         if self.platform not in ["web", "android", "ios"]:
             return False, "platform must be one of: web, android, ios"
@@ -72,6 +68,76 @@ class NotificationLogDTO(BaseDTO):
         return cls(
             id=data.get("id"),
             notice_id=data.get("notice_id"),
+            subscription_id=data.get("subscription_id"),
+            status=data.get("status"),
+            error_message=data.get("error_message"),
+            sent_at=data.get("sent_at"),
+        )
+
+
+@dataclass
+class PersonalNotificationRequestDTO(BaseDTO):
+    """개인 알림 발송 요청 DTO"""
+
+    student_no: str
+    title: str
+    content: str
+
+    def validate(self) -> tuple[bool, Optional[str]]:
+        """요청 데이터 검증"""
+        if not self.student_no or not self.student_no.strip():
+            return False, "student_no is required"
+
+        if not self.title or not self.title.strip():
+            return False, "title is required"
+
+        if not self.content or not self.content.strip():
+            return False, "content is required"
+
+        return True, None
+
+
+@dataclass
+class PersonalNotificationDTO(BaseDTO):
+    """개인 알림 원본 데이터 DTO"""
+
+    id: int
+    student_no: str
+    title: str
+    content: str
+    created_at: str
+    sent_by: Optional[str]
+
+    @classmethod
+    def from_supabase_data(cls, data: dict) -> "PersonalNotificationDTO":
+        """Supabase 응답 데이터를 DTO로 변환"""
+        return cls(
+            id=data.get("id"),
+            student_no=data.get("student_no"),
+            title=data.get("title"),
+            content=data.get("content"),
+            created_at=data.get("created_at"),
+            sent_by=data.get("sent_by"),
+        )
+
+
+@dataclass
+class PersonalNotificationLogDTO(BaseDTO):
+    """개인 알림 발송 결과 로그 DTO"""
+
+    id: int
+    personal_notification_id: int
+    subscription_id: int
+    status: str
+    error_message: Optional[str]
+    sent_at: str
+
+    @classmethod
+    def from_supabase_data(cls, data: dict) -> "PersonalNotificationLogDTO":
+        """Supabase 응답 데이터를 DTO로 변환"""
+        return cls(
+            id=data.get("id"),
+            personal_notification_id=data.get("personal_notification_id"),
             subscription_id=data.get("subscription_id"),
             status=data.get("status"),
             error_message=data.get("error_message"),

--- a/src/handlers/notifications_handler.py
+++ b/src/handlers/notifications_handler.py
@@ -6,7 +6,11 @@ import json
 import logging
 import os
 from src.utils.responses import create_success_response, create_error_response
-from src.services.notifications_service import send_notification_to_all
+from src.services.notifications_service import (
+    send_notification_to_all,
+    send_notification_to_student,
+)
+from src.dto.notification_dto import PersonalNotificationRequestDTO
 
 # 로거 설정
 logger = logging.getLogger()
@@ -120,4 +124,61 @@ def webhook_handler(event, context):
 
     except Exception as e:
         logger.error(f"❌ 웹훅 핸들러 오류: {e}")
+        return create_error_response("Internal server error", 500)
+
+
+def send_individual_notification_handler(event, context):
+    """
+    특정 학생에게 개인 알림을 발송합니다.
+
+    POST /notifications/individual
+    Body: {
+        "student_no": "string",
+        "title": "string",
+        "content": "string"
+    }
+    """
+    try:
+        logger.info("개인 알림 발송 요청 수신")
+
+        # 1. JSON 파싱
+        try:
+            body = json.loads(event.get("body", "{}"))
+        except json.JSONDecodeError:
+            logger.error("❌ 잘못된 JSON 형식")
+            return create_error_response("Invalid JSON format.", 400)
+
+        # 2. DTO 생성 및 검증
+        try:
+            request_dto = PersonalNotificationRequestDTO(
+                student_no=body.get("student_no"),
+                title=body.get("title"),
+                content=body.get("content"),
+            )
+        except Exception as e:
+            logger.error(f"❌ DTO 생성 실패: {e}")
+            return create_error_response(f"Invalid request data: {str(e)}", 400)
+
+        # 3. 데이터 검증
+        is_valid, error_msg = request_dto.validate()
+        if not is_valid:
+            logger.error(f"❌ 데이터 검증 실패: {error_msg}")
+            return create_error_response(error_msg, 400)
+
+        # 4. 서비스 호출
+        result, error = send_notification_to_student(
+            request_dto.student_no, request_dto.title, request_dto.content
+        )
+        if error:
+            logger.error(f"❌ 개인 알림 발송 실패: {error}")
+            return create_error_response(error, 500)
+
+        # 5. 성공 응답
+        logger.info(
+            f"✅ 개인 알림 발송 완료: student_no={request_dto.student_no}, 성공={result['success_count']}, 실패={result['failure_count']}"
+        )
+        return create_success_response(result)
+
+    except Exception as e:
+        logger.error(f"❌ 개인 알림 발송 핸들러 오류: {e}")
         return create_error_response("Internal server error", 500)

--- a/src/handlers/subscriptions_handler.py
+++ b/src/handlers/subscriptions_handler.py
@@ -23,39 +23,57 @@ def create_subscription_handler(event, context):
     POST /subscriptions
     Body: {
         "fcm_token": "string",
-        "student_no": "string",
         "platform": "web"
     }
     """
     try:
         logger.info("FCM 구독 생성 요청 수신")
 
-        # 1. JSON 파싱
+        # 1. 세션에서 사용자 정보 추출
+        user_info = event.get("user_info", {})
+        username = user_info.get("username")
+
+        if not username:
+            logger.error("❌ 사용자 정보를 찾을 수 없습니다 (인증 필요)")
+            return create_error_response(
+                "Unauthorized: user information not found", 401
+            )
+
+        logger.info(f"📱 사용자 {username}의 FCM 구독 생성 요청")
+
+        # 2. JSON 파싱
         try:
             body = json.loads(event.get("body", "{}"))
         except json.JSONDecodeError:
             logger.error("❌ 잘못된 JSON 형식")
             return create_error_response("Invalid JSON format.", 400)
 
-        # 2. DTO 생성 및 검증
+        # 3. DTO 생성 (student_no는 세션에서 추출한 username 사용)
         try:
             request_dto = SubscriptionCreateRequestDTO(
                 fcm_token=body.get("fcm_token"),
-                student_no=body.get("student_no"),
                 platform=body.get("platform", "web"),
             )
         except Exception as e:
             logger.error(f"❌ DTO 생성 실패: {e}")
             return create_error_response(f"Invalid request data: {str(e)}", 400)
 
-        # 3. 서비스 호출
-        subscription_dto, error = create_subscription(request_dto)
+        # 4. 데이터 검증
+        is_valid, error_msg = request_dto.validate()
+        if not is_valid:
+            logger.error(f"❌ 데이터 검증 실패: {error_msg}")
+            return create_error_response(error_msg, 400)
+
+        # 5. 서비스 호출 (student_no를 별도로 전달)
+        subscription_dto, error = create_subscription(request_dto, username)
         if error:
             logger.error(f"❌ 구독 생성 실패: {error}")
             return create_error_response(error, 500)
 
-        # 4. 성공 응답
-        logger.info(f"✅ FCM 구독 생성 완료: id={subscription_dto.id}")
+        # 6. 성공 응답
+        logger.info(
+            f"✅ FCM 구독 생성 완료: id={subscription_dto.id}, student_no={username}"
+        )
         return create_success_response(subscription_dto.to_dict())
 
     except Exception as e:

--- a/src/services/notifications_service.py
+++ b/src/services/notifications_service.py
@@ -6,7 +6,11 @@ import logging
 from typing import List, Tuple, Optional
 from src.utils.supabase_client import get_supabase_client
 from src.utils.fcm_client import send_multicast_notification
-from src.dto.notification_dto import SubscriptionDTO, NotificationLogDTO
+from src.dto.notification_dto import (
+    SubscriptionDTO,
+    NotificationLogDTO,
+    PersonalNotificationDTO,
+)
 
 # 로거 설정
 logger = logging.getLogger()
@@ -92,8 +96,9 @@ def send_notification_to_all(
         logger.info(f"📤 {len(fcm_tokens)}개 토큰으로 알림 발송 시작")
 
         # 3. FCM 멀티캐스트 발송
+        data = {"notice_id": str(notice_id)}
         success_count, failure_count, failed_tokens, invalid_tokens = (
-            send_multicast_notification(fcm_tokens, title, content)
+            send_multicast_notification(fcm_tokens, title, content, data)
         )
 
         # 4. 무효 토큰 구독 비활성화 및 로그 기록
@@ -213,5 +218,227 @@ def log_notification_result(
 
     except Exception as e:
         logger.error(f"❌ 알림 발송 결과 로깅 실패: {e}")
+        error_message = getattr(e, "message", str(e))
+        return False, error_message
+
+
+def send_notification_to_student(
+    student_no: str, title: str, content: str
+) -> Tuple[Optional[dict], Optional[str]]:
+    """
+    특정 학생에게 개인 알림을 발송합니다.
+
+    Args:
+        student_no: 학생 번호
+        title: 알림 제목
+        content: 알림 내용
+
+    Returns:
+        (발송 결과 딕셔너리, 에러 메시지)
+    """
+    try:
+        supabase = get_supabase_client("notify")
+        if not supabase:
+            return None, "Supabase client could not be initialized."
+
+        logger.info(f"개인 알림 발송 시작: student_no={student_no}, title={title}")
+
+        # 1. 개인 알림 원본 데이터를 personal_notifications 테이블에 저장
+        insert_data = {
+            "student_no": student_no,
+            "title": title,
+            "content": content,
+            # sent_by는 NULL (나중에 인증 시스템 개선 시 추가)
+        }
+
+        response = (
+            supabase.postgrest.schema("notify")
+            .from_("personal_notifications")
+            .insert(insert_data)
+            .execute()
+        )
+
+        if not response.data:
+            logger.error("❌ 개인 알림 데이터 저장 실패: 응답 데이터가 없습니다.")
+            return None, "Failed to save personal notification"
+
+        personal_notification = PersonalNotificationDTO.from_supabase_data(
+            response.data[0]
+        )
+        personal_notification_id = personal_notification.id
+
+        logger.info(
+            f"✅ 개인 알림 데이터 저장 완료: personal_notification_id={personal_notification_id}"
+        )
+
+        # 2. 해당 학생의 모든 활성 구독을 조회
+        subscriptions_response = (
+            supabase.postgrest.schema("notify")
+            .from_("subscriptions")
+            .select(
+                "id, fcm_token, student_no, is_active, platform, created_at, updated_at"
+            )
+            .eq("student_no", student_no)
+            .eq("is_active", True)
+            .execute()
+        )
+
+        if not subscriptions_response.data:
+            logger.info(f"⚠️ 학생 {student_no}의 활성 구독이 없습니다.")
+            return {
+                "success": True,
+                "personal_notification_id": personal_notification_id,
+                "student_no": student_no,
+                "total_devices": 0,
+                "success_count": 0,
+                "failure_count": 0,
+                "invalid_tokens": [],
+                "failed_tokens": [],
+                "message": "No active subscriptions found for this student",
+            }, None
+
+        subscriptions = [
+            SubscriptionDTO.from_supabase_data(sub_data)
+            for sub_data in subscriptions_response.data
+        ]
+
+        logger.info(f"📱 학생 {student_no}의 활성 구독 {len(subscriptions)}개 발견")
+
+        # 3. FCM 토큰 추출
+        fcm_tokens = [sub.fcm_token for sub in subscriptions]
+
+        # 4. FCM 멀티캐스트 발송
+        data = {"personal_notification_id": str(personal_notification_id)}
+        success_count, failure_count, failed_tokens, invalid_tokens = (
+            send_multicast_notification(fcm_tokens, title, content, data)
+        )
+
+        # 5. 무효 토큰 구독 비활성화
+        if invalid_tokens:
+            logger.info(f"🔄 무효 토큰 {len(invalid_tokens)}개 구독 비활성화 시작")
+            from src.services.subscriptions_service import (
+                deactivate_invalid_subscription,
+            )
+
+            for subscription in subscriptions:
+                if subscription.fcm_token in invalid_tokens:
+                    deactivate_success, deactivate_error = (
+                        deactivate_invalid_subscription(subscription.id)
+                    )
+                    if deactivate_success:
+                        logger.info(
+                            f"✅ 구독 {subscription.id} 비활성화 완료 (무효 토큰)"
+                        )
+                    else:
+                        logger.warning(
+                            f"⚠️ 구독 {subscription.id} 비활성화 실패: {deactivate_error}"
+                        )
+
+        # 6. 각 구독별 발송 결과를 personal_notification_logs에 기록
+        logger.info("📝 개인 알림 발송 결과 로그 기록 시작")
+        for subscription in subscriptions:
+            if subscription.fcm_token in invalid_tokens:
+                # 무효 토큰
+                log_success, log_error = log_personal_notification_result(
+                    personal_notification_id,
+                    subscription.id,
+                    "invalid_token",
+                    "Invalid FCM token",
+                )
+            elif subscription.fcm_token in failed_tokens:
+                # 발송 실패
+                log_success, log_error = log_personal_notification_result(
+                    personal_notification_id,
+                    subscription.id,
+                    "failed",
+                    "FCM send failed",
+                )
+            else:
+                # 발송 성공
+                log_success, log_error = log_personal_notification_result(
+                    personal_notification_id, subscription.id, "success"
+                )
+
+            if log_success:
+                logger.info(f"✅ 구독 {subscription.id} 로그 기록 완료")
+            else:
+                logger.warning(f"⚠️ 구독 {subscription.id} 로그 기록 실패: {log_error}")
+
+        # 7. 결과 반환
+        result = {
+            "success": True,
+            "personal_notification_id": personal_notification_id,
+            "student_no": student_no,
+            "total_devices": len(subscriptions),
+            "success_count": success_count,
+            "failure_count": failure_count,
+            "invalid_tokens": invalid_tokens,
+            "failed_tokens": failed_tokens,
+        }
+
+        logger.info(
+            f"✅ 개인 알림 발송 완료: student_no={student_no}, 성공={success_count}, 실패={failure_count}, 무효={len(invalid_tokens)}"
+        )
+
+        return result, None
+
+    except Exception as e:
+        logger.error(f"❌ 개인 알림 발송 실패: {e}")
+        error_message = getattr(e, "message", str(e))
+        return None, error_message
+
+
+def log_personal_notification_result(
+    personal_notification_id: int,
+    subscription_id: int,
+    status: str,
+    error_message: Optional[str] = None,
+) -> Tuple[bool, Optional[str]]:
+    """
+    개인 알림 발송 결과를 로그에 기록합니다.
+
+    Args:
+        personal_notification_id: 개인 알림 ID
+        subscription_id: 구독 ID
+        status: 발송 상태 (success, failed, invalid_token)
+        error_message: 에러 메시지 (실패 시)
+
+    Returns:
+        (성공 여부, 에러 메시지)
+    """
+    try:
+        supabase = get_supabase_client("notify")
+        if not supabase:
+            return False, "Supabase client could not be initialized."
+
+        logger.info(
+            f"개인 알림 발송 결과 로깅: personal_notification_id={personal_notification_id}, subscription_id={subscription_id}, status={status}"
+        )
+
+        insert_data = {
+            "personal_notification_id": personal_notification_id,
+            "subscription_id": subscription_id,
+            "status": status,
+            "error_message": error_message,
+        }
+
+        response = (
+            supabase.postgrest.schema("notify")
+            .from_("personal_notification_logs")
+            .insert(insert_data)
+            .execute()
+        )
+
+        if response.data:
+            logger.info(
+                f"✅ 개인 알림 발송 결과 로깅 완료: id={response.data[0].get('id')}"
+            )
+            return True, None
+        else:
+            logger.error("❌ 개인 알림 발송 결과 로깅 실패: 응답 데이터가 없습니다.")
+            return False, "Failed to log personal notification result"
+
+    except Exception as e:
+        logger.error(f"❌ 개인 알림 발송 결과 로깅 실패: {e}")
         error_message = getattr(e, "message", str(e))
         return False, error_message

--- a/src/services/subscriptions_service.py
+++ b/src/services/subscriptions_service.py
@@ -14,12 +14,14 @@ logger.setLevel(logging.INFO)
 
 def create_subscription(
     request_dto: SubscriptionCreateRequestDTO,
+    student_no: str,
 ) -> Tuple[Optional[SubscriptionDTO], Optional[str]]:
     """
     FCM 구독을 생성하거나 업데이트합니다.
 
     Args:
-        request_dto: 구독 생성 요청 DTO
+        request_dto: 구독 생성 요청 DTO (fcm_token, platform)
+        student_no: 학번 (세션에서 추출된 값)
 
     Returns:
         (SubscriptionDTO, 에러 메시지)
@@ -30,7 +32,7 @@ def create_subscription(
             return None, "Supabase client could not be initialized."
 
         logger.info(
-            f"FCM 구독 생성/업데이트: fcm_token={request_dto.fcm_token[:20]}..."
+            f"FCM 구독 생성/업데이트: student_no={student_no}, fcm_token={request_dto.fcm_token[:20]}..."
         )
 
         # 데이터 검증
@@ -41,7 +43,7 @@ def create_subscription(
         # UPSERT로 중복 방지 (fcm_token UNIQUE 제약 활용)
         insert_data = {
             "fcm_token": request_dto.fcm_token,
-            "student_no": request_dto.student_no,
+            "student_no": student_no,
             "platform": request_dto.platform,
             "is_active": True,
         }

--- a/src/utils/routing.py
+++ b/src/utils/routing.py
@@ -29,6 +29,10 @@ ROUTE_OVERRIDES: Dict[Tuple[str, str], Tuple[str, str]] = {
         "notifications_handler",
         "send_notification_handler",
     ),
+    ("POST", "notifications/individual"): (
+        "notifications_handler",
+        "send_individual_notification_handler",
+    ),
     ("GET", "notices/filter"): ("notices_handler", "filter"),
 }
 


### PR DESCRIPTION
## 📌 작업 개요

1. **구독 생성 시 클라이언트의 학번 처리 방식 변경** - 세션에서 자동 추출
2. **개인 알림 발송 기능 추가** - 특정 학생 타겟팅

## 🔒 작업 1: 구독 생성 시 클라이언트의 학번 처리 방식 변경

### 문제
- 프론트엔드가 `student_no`를 요청 바디에 포함하여 전송
- 그런데 프론트엔드가 클라이언트에 정확한 학번을 알 방법이 딱히 없음
- 모든 구독이 하드코딩된 학번(`20243105`)으로 저장됨

### 해결
- 세션(JWT)에서 **`username`** 추출하여 학번으로 사용
- 요청 바디에서 `student_no` 필드 제거
- 서버가 자동으로 인증된 사용자의 학번 할당

### 변경 사항
```diff
POST /api/subscriptions
{
  "fcm_token": "abc...",
- "student_no": "20243105",
  "platform": "web"
}
```

**수정 파일:**
- `src/dto/notification_dto.py` - `student_no` 필드 제거
- `src/services/subscriptions_service.py` - `student_no` 별도 파라미터로 받도록 수정
- `src/handlers/subscriptions_handler.py` - 세션에서 학번 추출 로직 추가
- `docs/openapi.yml` - API 스펙 업데이트

# 이제 반드시 Cognito의 username 에 학번을 입력합니다

## 📬 작업 2: 개인 알림 발송 기능

### 기능
특정 학생에게만 개인 맞춤형 푸시 알림 발송

### API
```http
POST /api/notifications/individual
{
  "student_no": "20243069",
  "title": "관리비 청구 안내",
  "content": "9월 관리비 청구서가 발행되었습니다."
}
```

### 동작
1. `personal_notifications` 테이블에 원본 저장
2. 해당 학생의 모든 활성 구독 조회
3. FCM 멀티캐스트로 모든 기기에 발송
4. `personal_notification_logs`에 발송 결과 기록

### 활용 사례
- 관리비 청구 알림
- 개별 공지사항
- 점호/벌점 안내

**추가 파일:**
- `src/handlers/notifications_handler.py` - `send_individual_notification_handler` 추가
- `src/services/notifications_service.py` - `send_notification_to_student` 추가
- `src/dto/notification_dto.py` - 개인 알림 DTO 추가
- `docs/openapi.yml` - API 문서 추가

## 📊 테스트 결과

### 구독 생성
- ✅ username=20243069로 로그인 → DB에 student_no="20243069" 저장

### 개인 알림
- ✅ 해당 학생의 기기로 정상 발송
- ✅ 발송 결과 로그 정상 기록
- ✅ 활성 구독 없는 경우 처리 정상

### FCM 발송
- ✅ 전체 알림 정상 발송
- ✅ 개인 알림 정상 발송