### PR TITLE
feat: 외박 기능 구현

### DIFF
--- a/docs/openapi.yml
+++ b/docs/openapi.yml
@@ -245,6 +245,176 @@ paths:
               schema:
                 $ref: "#/components/schemas/Error"
 
+  /api/overnight-stay:
+    post:
+      summary: 외박 신청 생성
+      description: 학생이 외박을 신청합니다. 학기당 승인된 외박은 최대 3회까지 허용되며, 동시에 하나의 대기중 신청만 존재할 수 있습니다. 학번은 세션 정보에서 자동으로 추출됩니다.
+      tags:
+        - OvernightStays
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/OvernightStayCreateRequest"
+            example:
+              startDate: "2025-11-24"
+              endDate: "2025-11-25"
+              reason: "청소 점호 탈주"
+              semester: "2025-2"
+      responses:
+        "201":
+          description: 외박 신청이 생성되었습니다.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/OvernightStay"
+        "400":
+          description: 잘못된 요청 (학기당 제한 초과, 날짜 오류 등)
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "404":
+          description: 학생을 찾을 수 없음
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "500":
+          description: 서버 내부 오류
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+
+    get:
+      summary: 내 외박 신청 내역 조회
+      description: 학생이 현재 학기의 외박 신청 내역과 요약 정보를 조회합니다. 학번은 세션 정보에서 자동으로 추출됩니다.
+      tags:
+        - OvernightStays
+      parameters: []
+      responses:
+        "200":
+          description: 외박 신청 목록과 요약 정보가 반환되었습니다.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/OvernightStayStudentList"
+        "400":
+          description: 잘못된 요청 (필수 파라미터 누락 등)
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "404":
+          description: 학생을 찾을 수 없음
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "500":
+          description: 서버 내부 오류
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+
+  /api/overnight-stays:
+    get:
+      summary: 외박 신청 목록 조회 (사감용)
+      description: 사감이 외박 신청 목록을 조회합니다. 학기와 학번으로 필터링할 수 있으며 페이지네이션을 지원합니다.
+      tags:
+        - OvernightStays
+      parameters:
+        - name: semester
+          in: query
+          required: false
+          description: 학기 필터 (2025-2)
+          schema:
+            type: string
+        - name: studentIdNum
+          in: query
+          required: false
+          description: 학번 필터
+          schema:
+            type: string
+        - name: page
+          in: query
+          required: false
+          description: 페이지 번호 (기본값 1)
+          schema:
+            type: integer
+            minimum: 1
+            default: 1
+        - name: pageSize
+          in: query
+          required: false
+          description: 페이지 크기 (기본값 10)
+          schema:
+            type: integer
+            minimum: 1
+            default: 10
+      responses:
+        "200":
+          description: 외박 신청 목록이 반환되었습니다.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/OvernightStayAdminList"
+        "400":
+          description: 잘못된 요청 (페이지 번호/크기 오류 등)
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "500":
+          description: 서버 내부 오류
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+
+    patch:
+      summary: 외박 신청 승인/거부
+      description: 사감이 외박 신청을 승인하거나 거부합니다.
+      tags:
+        - OvernightStays
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/OvernightStayStatusUpdateRequest"
+            example:
+              id: 1
+              status: "approved"
+      responses:
+        "200":
+          description: 외박 신청 상태가 업데이트되었습니다.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/OvernightStay"
+        "400":
+          description: 잘못된 요청 (허용되지 않은 상태 값 등)
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "404":
+          description: 외박 신청을 찾을 수 없음
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "500":
+          description: 서버 내부 오류
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+
   /api/notices:
     get:
       summary: 공지사항 목록 조회 (페이지네이션)
@@ -1252,6 +1422,169 @@ components:
           description: 퇴사 날짜 (YYYY-MM-DD 형식, 선택사항)
           example: "2024-08-31"
 
+    OvernightStay:
+      type: object
+      description: 외박 신청 정보
+      properties:
+        id:
+          type: integer
+          description: 외박 신청 ID
+          example: 1
+        studentIdNum:
+          type: string
+          description: 학번
+          example: "20201234"
+        studentName:
+          type: string
+          description: 학생 이름 (사감용 목록에서 제공)
+          example: "홍길동"
+        roomNumber:
+          type: integer
+          description: 호실 번호 (사감용 목록에서 제공)
+          example: 301
+        startDate:
+          type: string
+          format: date
+          description: 외박 시작일
+          example: "2024-12-25"
+        endDate:
+          type: string
+          format: date
+          description: 외박 종료일
+          example: "2024-12-26"
+        reason:
+          type: string
+          description: 외박 사유
+          example: "가족 행사 참석"
+        status:
+          type: string
+          description: 신청 상태
+          enum: [pending, approved, rejected]
+          example: "pending"
+        semester:
+          type: string
+          description: 학기 정보 (2024-2)
+          example: "2024-2"
+        createdAt:
+          type: string
+          format: date-time
+          description: 신청 생성일시
+          example: "2024-11-06T14:30:00Z"
+
+    OvernightStayCreateRequest:
+      type: object
+      description: 외박 신청 생성 요청
+      required:
+        - startDate
+        - endDate
+        - reason
+        - semester
+      properties:
+        startDate:
+          type: string
+          format: date
+          description: 외박 시작일
+          example: "2024-12-25"
+        endDate:
+          type: string
+          format: date
+          description: 외박 종료일
+          example: "2024-12-26"
+        reason:
+          type: string
+          description: 외박 사유
+          example: "가족 행사 참석"
+        semester:
+          type: string
+          description: 학기 정보 (2024-2)
+          example: "2024-2"
+
+    OvernightStaySummary:
+      type: object
+      description: 외박 신청 요약 정보
+      properties:
+        currentSemester:
+          type: string
+          description: 현재 학기
+          example: "2024-2"
+        approvedCount:
+          type: integer
+          description: 승인된 외박 횟수
+          example: 1
+        remainingCount:
+          type: integer
+          description: 남은 외박 가능 횟수
+          example: 2
+
+    OvernightStayStudentList:
+      type: object
+      description: 학생용 외박 신청 목록 응답
+      properties:
+        data:
+          type: array
+          items:
+            $ref: "#/components/schemas/OvernightStay"
+        summary:
+          $ref: "#/components/schemas/OvernightStaySummary"
+
+    OvernightStayPageInfo:
+      type: object
+      description: 외박 신청 페이지 정보
+      properties:
+        page:
+          type: integer
+          description: 현재 페이지 번호
+          example: 1
+        pageSize:
+          type: integer
+          description: 페이지 크기
+          example: 10
+        totalItems:
+          type: integer
+          description: 전체 데이터 수
+          example: 25
+        totalPages:
+          type: integer
+          description: 전체 페이지 수
+          example: 3
+
+    OvernightStayAdminList:
+      type: object
+      description: 사감용 외박 신청 목록 응답
+      properties:
+        data:
+          type: array
+          items:
+            $ref: "#/components/schemas/OvernightStay"
+        pageInfo:
+          $ref: "#/components/schemas/OvernightStayPageInfo"
+        total:
+          type: integer
+          description: 전체 신청 건수
+          example: 3
+
+    OvernightStayStatusUpdateRequest:
+      type: object
+      description: 외박 신청 상태 변경 요청
+      required:
+        - id
+        - status
+      properties:
+        id:
+          type: integer
+          description: 외박 신청 ID
+          example: 1
+        status:
+          type: string
+          description: 변경할 상태 (approved 또는 rejected)
+          enum: [approved, rejected]
+          example: "approved"
+        checkOutDate:
+          type: string
+          format: date
+          description: 퇴사 날짜 (YYYY-MM-DD 형식, 선택사항)
+          example: "2024-08-31"
+
     Notice:
       type: object
       description: 공지사항 정보
@@ -1739,3 +2072,5 @@ tags:
     description: FCM 푸시 알림 관련 API
   - name: Auth
     description: 인증 관련 API (스웨거에서는 동작하지 않음)
+  - name: OvernightStays
+    description: 외박 신청 관련 API

--- a/src/dto/__init__.py
+++ b/src/dto/__init__.py
@@ -27,6 +27,15 @@ from .notification_dto import (
     SubscriptionCreateRequestDTO,
     NotificationLogDTO,
 )
+from .overnight_stay_dto import (
+    OvernightStayDTO,
+    OvernightStayCreateRequestDTO,
+    OvernightStayStatusUpdateRequestDTO,
+    OvernightStayStudentListDTO,
+    OvernightStaySummaryDTO,
+    OvernightStayAdminListDTO,
+    OvernightStayPageInfoDTO,
+)
 
 __all__ = [
     "BaseDTO",
@@ -52,4 +61,11 @@ __all__ = [
     "SubscriptionDTO",
     "SubscriptionCreateRequestDTO",
     "NotificationLogDTO",
+    "OvernightStayDTO",
+    "OvernightStayCreateRequestDTO",
+    "OvernightStayStatusUpdateRequestDTO",
+    "OvernightStayStudentListDTO",
+    "OvernightStaySummaryDTO",
+    "OvernightStayAdminListDTO",
+    "OvernightStayPageInfoDTO",
 ]

--- a/src/dto/overnight_stay_dto.py
+++ b/src/dto/overnight_stay_dto.py
@@ -1,0 +1,159 @@
+"""
+외박 신청 관련 DTO 클래스들을 정의합니다.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Optional
+
+from .base_dto import BaseDTO
+
+
+@dataclass
+class OvernightStayCreateRequestDTO(BaseDTO):
+    """외박 신청 생성 요청 DTO"""
+
+    startDate: str
+    endDate: str
+    reason: str
+    semester: str
+    studentIdNum: Optional[str] = None
+
+    def validate(self) -> tuple[bool, Optional[str]]:
+        """요청 데이터 검증"""
+        if not self.startDate or not self.startDate.strip():
+            return False, "startDate is required."
+        if not self.endDate or not self.endDate.strip():
+            return False, "endDate is required."
+        if not self.reason or not self.reason.strip():
+            return False, "reason is required."
+        if not self.semester or not self.semester.strip():
+            return False, "semester is required."
+        return True, None
+
+
+@dataclass
+class OvernightStayStatusUpdateRequestDTO(BaseDTO):
+    """외박 신청 상태 변경 요청 DTO"""
+
+    id: int
+    status: str
+
+    def validate(self) -> tuple[bool, Optional[str]]:
+        """요청 데이터 검증"""
+        if not isinstance(self.id, int) or self.id <= 0:
+            return False, "id must be a positive integer."
+        if self.status not in {"approved", "rejected"}:
+            return False, "status must be either 'approved' or 'rejected'."
+        return True, None
+
+
+@dataclass
+class OvernightStayDTO(BaseDTO):
+    """외박 신청 응답 DTO"""
+
+    id: int
+    studentIdNum: str
+    startDate: str
+    endDate: str
+    reason: str
+    status: str
+    semester: str
+    createdAt: str
+    studentName: Optional[str] = None
+    roomNumber: Optional[int] = None
+
+    @classmethod
+    def from_supabase_data(cls, data: dict) -> "OvernightStayDTO":
+        """Supabase 데이터에서 OvernightStayDTO 생성"""
+        return cls(
+            id=data["id"],
+            studentIdNum=data["student_no"],
+            startDate=data["start_date"],
+            endDate=data["end_date"],
+            reason=data["reason"],
+            status=data["status"],
+            semester=data["semester"],
+            createdAt=data["created_at"],
+            studentName=data.get("student_name"),
+            roomNumber=data.get("room_number"),
+        )
+
+
+@dataclass
+class OvernightStaySummaryDTO(BaseDTO):
+    """외박 신청 요약 정보 DTO"""
+
+    currentSemester: str
+    approvedCount: int
+    remainingCount: int
+
+
+@dataclass
+class OvernightStayStudentListDTO(BaseDTO):
+    """학생용 외박 신청 목록 DTO"""
+
+    data: list[OvernightStayDTO]
+    summary: OvernightStaySummaryDTO
+
+    def to_dict(self) -> dict:
+        return {
+            "data": [item.to_dict() for item in self.data],
+            "summary": self.summary.to_dict(),
+        }
+
+    @classmethod
+    def from_supabase_data(
+        cls,
+        data_list: list[dict],
+        summary: OvernightStaySummaryDTO,
+    ) -> "OvernightStayStudentListDTO":
+        """Supabase 데이터와 요약 정보에서 DTO 생성"""
+        stays = [OvernightStayDTO.from_supabase_data(data) for data in data_list]
+        return cls(data=stays, summary=summary)
+
+
+@dataclass
+class OvernightStayPageInfoDTO(BaseDTO):
+    """외박 신청 페이지 정보 DTO"""
+
+    page: int
+    pageSize: int
+    totalItems: int
+    totalPages: int
+
+
+@dataclass
+class OvernightStayAdminListDTO(BaseDTO):
+    """사감용 외박 신청 목록 DTO"""
+
+    data: list[OvernightStayDTO]
+    pageInfo: OvernightStayPageInfoDTO
+    total: int
+
+    def to_dict(self) -> dict:
+        return {
+            "data": [item.to_dict() for item in self.data],
+            "pageInfo": self.pageInfo.to_dict(),
+            "total": self.total,
+        }
+
+    @classmethod
+    def from_supabase_data(
+        cls,
+        data_list: list[dict],
+        total_items: int,
+        page: int,
+        page_size: int,
+    ) -> "OvernightStayAdminListDTO":
+        """Supabase 데이터와 페이지 정보에서 DTO 생성"""
+        stays = [OvernightStayDTO.from_supabase_data(data) for data in data_list]
+        total_pages = (total_items + page_size - 1) // page_size if page_size else 1
+        page_info = OvernightStayPageInfoDTO(
+            page=page,
+            pageSize=page_size,
+            totalItems=total_items,
+            totalPages=total_pages,
+        )
+        return cls(data=stays, pageInfo=page_info, total=total_items)

--- a/src/handlers/overnight_stays_handler.py
+++ b/src/handlers/overnight_stays_handler.py
@@ -1,0 +1,185 @@
+import json
+import logging
+from typing import Tuple
+
+from src.services import overnight_stays_service
+from src.utils import responses
+from src.dto import (
+    OvernightStayDTO,
+    OvernightStayCreateRequestDTO,
+    OvernightStayStatusUpdateRequestDTO,
+    OvernightStayStudentListDTO,
+    OvernightStaySummaryDTO,
+    OvernightStayAdminListDTO,
+)
+
+
+logger = logging.getLogger()
+logger.setLevel(logging.INFO)
+
+
+def _map_service_error_to_status(error_message: str) -> Tuple[str, int]:
+    """서비스 레이어의 에러 메시지를 HTTP 상태 코드로 매핑합니다."""
+    if error_message in {"Student not found", "Overnight stay not found"}:
+        return error_message, 404
+    if error_message in {
+        "Invalid date format. Use YYYY-MM-DD.",
+        "End date cannot be earlier than start date.",
+        "Overnight stay limit exceeded for this semester.",
+        "Pending overnight stay request already exists.",
+        "Invalid status. Must be 'approved' or 'rejected'.",
+        "Page must be greater than 0",
+    }:
+        return error_message, 400
+    return error_message, 500
+
+
+def create(event, context):
+    """POST /api/overnight-stay - 학생 외박 신청 생성"""
+
+    logger.info("✅ Processing create overnight stay request")
+
+    try:
+        body = json.loads(event.get("body", "{}"))
+        request_dto = OvernightStayCreateRequestDTO.from_dict(body)
+        is_valid, validation_error = request_dto.validate()
+        if not is_valid:
+            return responses.create_error_response(validation_error, 400)
+
+        user_info = event.get("user_info", {})
+        student_no = user_info.get("username")
+        if not student_no:
+            logger.error("❌ Unauthorized request: student number missing in session")
+            return responses.create_error_response("Unauthorized", 401)
+
+        result, error = overnight_stays_service.create_overnight_stay(
+            student_no=student_no,
+            start_date=request_dto.startDate,
+            end_date=request_dto.endDate,
+            reason=request_dto.reason,
+            semester=request_dto.semester,
+        )
+
+        if error:
+            message, status = _map_service_error_to_status(error)
+            return responses.create_error_response(message, status)
+
+        response_dto = OvernightStayDTO.from_supabase_data(result)
+        return responses.create_success_response(response_dto.to_dict(), 201)
+
+    except json.JSONDecodeError:
+        return responses.create_error_response("Invalid JSON format.", 400)
+    except Exception as e:
+        logger.error(f"❌ Failed to create overnight stay: {e}")
+        return responses.create_error_response("Internal server error.", 500)
+
+
+def get_student_requests(event, context):
+    """GET /api/overnight-stay - 학생 외박 신청 목록 조회"""
+
+    logger.info("✅ Processing get student overnight stays request")
+
+    user_info = event.get("user_info", {})
+    student_no = user_info.get("username")
+
+    if not student_no:
+        logger.error("❌ Unauthorized request: student number missing in session")
+        return responses.create_error_response("Unauthorized", 401)
+
+    try:
+        data, summary, error = overnight_stays_service.get_student_overnight_stays(
+            student_no
+        )
+
+        if error:
+            message, status = _map_service_error_to_status(error)
+            return responses.create_error_response(message, status)
+
+        stays = [OvernightStayDTO.from_supabase_data(item) for item in data]
+        summary_dto = OvernightStaySummaryDTO.from_dict(summary)
+        response_dto = OvernightStayStudentListDTO(data=stays, summary=summary_dto)
+
+        return responses.create_success_response(response_dto.to_dict())
+
+    except Exception as e:
+        logger.error(f"❌ Failed to fetch student overnight stays: {e}")
+        return responses.create_error_response("Internal server error.", 500)
+
+
+def get_admin_requests(event, context):
+    """GET /api/overnight-stays - 사감 외박 신청 목록 조회"""
+
+    logger.info("✅ Processing admin overnight stays list request")
+
+    query_params = event.get("queryStringParameters") or {}
+
+    semester = query_params.get("semester")
+    student_no = query_params.get("studentIdNum")
+
+    page_str = query_params.get("page", "1")
+    page_size_str = query_params.get("pageSize", "10")
+
+    try:
+        page = int(page_str)
+        page_size = int(page_size_str)
+    except ValueError:
+        return responses.create_error_response("Invalid page or pageSize format.", 400)
+
+    try:
+        data, total_count, resolved_page_size, error = (
+            overnight_stays_service.get_overnight_stays(
+                page=page,
+                page_size=page_size,
+                semester=semester,
+                student_no=student_no,
+            )
+        )
+
+        if error:
+            message, status = _map_service_error_to_status(error)
+            return responses.create_error_response(message, status)
+
+        response_dto = OvernightStayAdminListDTO.from_supabase_data(
+            data_list=data,
+            total_items=total_count or 0,
+            page=page,
+            page_size=resolved_page_size or page_size,
+        )
+
+        return responses.create_success_response(response_dto.to_dict())
+
+    except Exception as e:
+        logger.error(f"❌ Failed to fetch admin overnight stays: {e}")
+        return responses.create_error_response("Internal server error.", 500)
+
+
+def update_status(event, context):
+    """PATCH /api/overnight-stays - 외박 신청 상태 변경"""
+
+    logger.info("✅ Processing overnight stay status update request")
+
+    try:
+        body = json.loads(event.get("body", "{}"))
+    except json.JSONDecodeError:
+        return responses.create_error_response("Invalid JSON format.", 400)
+
+    request_dto = OvernightStayStatusUpdateRequestDTO.from_dict(body)
+    is_valid, validation_error = request_dto.validate()
+    if not is_valid:
+        return responses.create_error_response(validation_error, 400)
+
+    try:
+        result, error = overnight_stays_service.update_overnight_stay_status(
+            request_dto.id, request_dto.status
+        )
+
+        if error:
+            message, status = _map_service_error_to_status(error)
+            return responses.create_error_response(message, status)
+
+        response_dto = OvernightStayDTO.from_supabase_data(result)
+        return responses.create_success_response(response_dto.to_dict())
+
+    except Exception as e:
+        logger.error(f"❌ Failed to update overnight stay status: {e}")
+        return responses.create_error_response("Internal server error.", 500)

--- a/src/services/overnight_stays_service.py
+++ b/src/services/overnight_stays_service.py
@@ -1,0 +1,355 @@
+import logging
+from datetime import datetime, date
+from typing import Optional, Tuple
+
+from src.utils.supabase_client import get_supabase_client
+
+
+logger = logging.getLogger()
+logger.setLevel(logging.INFO)
+
+MAX_APPROVED_PER_SEMESTER = 3
+MAX_PENDING_REQUESTS = 1
+
+
+def _parse_date(date_str: str) -> date:
+    """문자열을 날짜로 파싱합니다."""
+    return datetime.strptime(date_str, "%Y-%m-%d").date()
+
+
+def _ensure_student_exists(
+    supabase, student_no: str
+) -> Tuple[Optional[dict], Optional[str]]:
+    """학생 존재 여부를 확인하고 학생 정보를 반환합니다."""
+    response = (
+        supabase.postgrest.schema("core")
+        .from_("students")
+        .select("studentNo, name, room_number")
+        .eq("studentNo", student_no)
+        .limit(1)
+        .execute()
+    )
+
+    if not response.data:
+        logger.info(f"❌ studentNo={student_no} 학생을 찾을 수 없습니다.")
+        return None, "Student not found"
+
+    return response.data[0], None
+
+
+def _get_current_semester(reference_date: Optional[date] = None) -> str:
+    """현재 날짜 기준으로 학기를 계산합니다."""
+    today = reference_date or date.today()
+    year = today.year
+
+    if 3 <= today.month <= 8:
+        return f"{year}-1"
+    if today.month >= 9:
+        return f"{year}-2"
+    # 1월, 2월은 이전 해 2학기
+    return f"{year - 1}-2"
+
+
+def _build_joined_row(row: dict) -> dict:
+    """조인된 학생 정보를 평탄화합니다."""
+    student_info = row.pop("students", None)
+    if student_info:
+        row["student_name"] = student_info.get("name")
+        row["room_number"] = student_info.get("room_number")
+    return row
+
+
+def create_overnight_stay(
+    student_no: str,
+    start_date: str,
+    end_date: str,
+    reason: str,
+    semester: str,
+):
+    """새 외박 신청을 생성합니다."""
+
+    try:
+        start = _parse_date(start_date)
+        end = _parse_date(end_date)
+    except ValueError:
+        return None, "Invalid date format. Use YYYY-MM-DD."
+
+    if end < start:
+        return None, "End date cannot be earlier than start date."
+
+    try:
+        supabase = get_supabase_client("core")
+        if not supabase:
+            return None, "Supabase client could not be initialized."
+
+        student_info, error = _ensure_student_exists(supabase, student_no)
+        if error:
+            return None, error
+
+        # 학기당 승인 횟수 제한 확인
+        approved_response = (
+            supabase.postgrest.schema("core")
+            .from_("overnight_stays")
+            .select("id", count="exact")
+            .eq("student_no", student_no)
+            .eq("semester", semester)
+            .eq("status", "approved")
+            .execute()
+        )
+
+        approved_count = approved_response.count or 0
+        if approved_count >= MAX_APPROVED_PER_SEMESTER:
+            logger.info(
+                f"❌ studentNo={student_no} 학기 {semester} 외박 승인 횟수 초과"
+            )
+            return None, "Overnight stay limit exceeded for this semester."
+
+        # 대기중 신청 개수 제한 확인
+        pending_response = (
+            supabase.postgrest.schema("core")
+            .from_("overnight_stays")
+            .select("id", count="exact")
+            .eq("student_no", student_no)
+            .eq("status", "pending")
+            .execute()
+        )
+
+        pending_count = pending_response.count or 0
+        if pending_count >= MAX_PENDING_REQUESTS:
+            logger.info(f"❌ studentNo={student_no} 기존 대기중 외박 신청 존재")
+            return None, "Pending overnight stay request already exists."
+
+        insert_data = {
+            "student_no": student_no,
+            "start_date": start_date,
+            "end_date": end_date,
+            "reason": reason,
+            "semester": semester,
+        }
+
+        response = (
+            supabase.postgrest.schema("core")
+            .from_("overnight_stays")
+            .insert(insert_data, returning="representation")
+            .execute()
+        )
+
+        if not response.data:
+            logger.error("❌ 외박 신청 생성 실패: 응답 데이터 없음")
+            return None, "Failed to create overnight stay"
+
+        created = response.data[0]
+        created["student_name"] = student_info.get("name")
+        created["room_number"] = student_info.get("room_number")
+
+        logger.info(
+            f"✅ 외박 신청 생성 완료: id={created['id']}, student_no={student_no}, semester={semester}"
+        )
+
+        return created, None
+
+    except Exception as e:
+        logger.error(f"❌ 외박 신청 생성 실패: {e}")
+        error_message = getattr(e, "message", str(e))
+        return None, error_message
+
+
+def get_student_overnight_stays(student_no: str):
+    """학생의 현재 학기 외박 신청 목록과 요약 정보를 반환합니다."""
+
+    try:
+        supabase = get_supabase_client("core")
+        if not supabase:
+            return None, None, "Supabase client could not be initialized."
+
+        student_info, error = _ensure_student_exists(supabase, student_no)
+        if error:
+            return None, None, error
+
+        current_semester = _get_current_semester()
+
+        response = (
+            supabase.postgrest.schema("core")
+            .from_("overnight_stays")
+            .select(
+                "id, student_no, start_date, end_date, reason, status, semester, created_at"
+            )
+            .eq("student_no", student_no)
+            .eq("semester", current_semester)
+            .order("created_at", desc=True)
+            .execute()
+        )
+
+        data = response.data or []
+
+        approved_response = (
+            supabase.postgrest.schema("core")
+            .from_("overnight_stays")
+            .select("id", count="exact")
+            .eq("student_no", student_no)
+            .eq("semester", current_semester)
+            .eq("status", "approved")
+            .execute()
+        )
+
+        approved_count = approved_response.count or 0
+        remaining_count = max(0, MAX_APPROVED_PER_SEMESTER - approved_count)
+
+        summary = {
+            "currentSemester": current_semester,
+            "approvedCount": approved_count,
+            "remainingCount": remaining_count,
+        }
+
+        logger.info(
+            f"✅ 학생 외박 신청 조회 완료: student_no={student_no}, 학기={current_semester}, 건수={len(data)}"
+        )
+
+        return data, summary, None
+
+    except Exception as e:
+        logger.error(f"❌ 학생 외박 신청 조회 실패: {e}")
+        error_message = getattr(e, "message", str(e))
+        return None, None, error_message
+
+
+def get_overnight_stays(
+    page: int = 1,
+    page_size: int = 10,
+    semester: Optional[str] = None,
+    student_no: Optional[str] = None,
+):
+    """사감용 외박 신청 목록을 조회합니다."""
+
+    if page < 1:
+        return None, None, None, "Page must be greater than 0"
+
+    try:
+        supabase = get_supabase_client("core")
+        if not supabase:
+            return None, None, None, "Supabase client could not be initialized."
+
+        offset = (page - 1) * page_size
+
+        query = (
+            supabase.postgrest.schema("core")
+            .from_("overnight_stays")
+            .select(
+                "id, student_no, start_date, end_date, reason, status, semester, created_at, students(name, room_number)",
+                count="exact",
+            )
+            .order("created_at", desc=True)
+        )
+
+        if semester:
+            query = query.eq("semester", semester)
+        if student_no:
+            query = query.eq("student_no", student_no)
+
+        query = query.range(offset, offset + page_size - 1)
+
+        response = query.execute()
+
+        data = response.data or []
+        total_count = response.count or 0
+
+        processed_data = [_build_joined_row(row) for row in data]
+
+        logger.info(
+            f"✅ 사감 외박 목록 조회 완료: page={page}, page_size={page_size}, total={total_count}"
+        )
+
+        return processed_data, total_count, page_size, None
+
+    except Exception as e:
+        logger.error(f"❌ 사감 외박 목록 조회 실패: {e}")
+        error_message = getattr(e, "message", str(e))
+        return None, None, None, error_message
+
+
+def update_overnight_stay_status(overnight_id: int, status: str):
+    """외박 신청 상태를 업데이트합니다."""
+
+    if status not in {"approved", "rejected"}:
+        return None, "Invalid status. Must be 'approved' or 'rejected'."
+
+    try:
+        supabase = get_supabase_client("core")
+        if not supabase:
+            return None, "Supabase client could not be initialized."
+
+        # 기존 데이터 조회
+        existing_response = (
+            supabase.postgrest.schema("core")
+            .from_("overnight_stays")
+            .select(
+                "id, student_no, start_date, end_date, reason, status, semester, created_at, students(name, room_number)"
+            )
+            .eq("id", overnight_id)
+            .limit(1)
+            .execute()
+        )
+
+        if not existing_response.data:
+            logger.info(f"❌ 외박 신청을 찾을 수 없음: id={overnight_id}")
+            return None, "Overnight stay not found"
+
+        existing_row = _build_joined_row(existing_response.data[0])
+
+        if existing_row["status"] == status:
+            logger.info(
+                f"⚠️ 외박 신청 상태 변경 불필요: id={overnight_id}, status={status}"
+            )
+            return existing_row, None
+
+        update_response = (
+            supabase.postgrest.schema("core")
+            .from_("overnight_stays")
+            .update({"status": status}, returning="representation")
+            .eq("id", overnight_id)
+            .execute()
+        )
+
+        if not update_response.data:
+            logger.error("❌ 외박 신청 상태 업데이트 실패: 응답 데이터 없음")
+            return None, "Failed to update overnight stay status"
+
+        updated_row = existing_row
+        updated_row["status"] = status
+
+        logger.info(
+            f"✅ 외박 신청 상태 변경 완료: id={overnight_id}, new_status={status}"
+        )
+
+        # 승인/거부 알림 발송
+        try:
+            from src.services.notifications_service import send_notification_to_student
+
+            title = "외박 신청 결과 안내"
+            if status == "approved":
+                content = f"{updated_row['start_date']} ~ {updated_row['end_date']} 외박 신청이 승인되었습니다."
+            else:
+                content = f"{updated_row['start_date']} ~ {updated_row['end_date']} 외박 신청이 거부되었습니다."
+
+            notification_result, notification_error = send_notification_to_student(
+                updated_row["student_no"], title, content
+            )
+
+            if notification_error:
+                logger.warning(
+                    f"⚠️ 외박 신청 상태 변경 알림 발송 실패: id={overnight_id}, error={notification_error}"
+                )
+            else:
+                logger.info(
+                    f"📢 외박 신청 상태 변경 알림 발송 성공: id={overnight_id}, result={notification_result}"
+                )
+
+        except Exception as notify_error:
+            logger.warning(f"⚠️ 외박 신청 상태 변경 알림 처리 중 오류: {notify_error}")
+
+        return updated_row, None
+
+    except Exception as e:
+        logger.error(f"❌ 외박 신청 상태 업데이트 실패: {e}")
+        error_message = getattr(e, "message", str(e))
+        return None, error_message

--- a/src/utils/routing.py
+++ b/src/utils/routing.py
@@ -13,6 +13,8 @@ MODULE_MAP: Dict[str, str] = {
     "bill": "bill_handler",
     "subscriptions": "subscriptions_handler",
     "notifications": "notifications_handler",
+    "overnight-stay": "overnight_stays_handler",
+    "overnight-stays": "overnight_stays_handler",
 }
 
 # 2) 예외 라우팅: (METHOD, path_after_api)
@@ -54,6 +56,10 @@ DEFAULT_FUNC_RULES: Dict[Tuple[str, str], str] = {
     ("POST", "student"): "create",
     ("PUT", "student"): "update",
     ("DELETE", "student"): "delete",
+    ("POST", "overnight-stay"): "create",
+    ("GET", "overnight-stay"): "get_student_requests",
+    ("GET", "overnight-stays"): "get_admin_requests",
+    ("PATCH", "overnight-stays"): "update_status",
 }
 
 


### PR DESCRIPTION
## 📋 개요
학생의 외박 신청 및 사감의 승인/거부 기능을 구현했습니다. 학생은 외박을 신청하고 조회할 수 있으며, 사감은 외박 신청 목록을 조회하고 승인/거부할 수 있습니다.

## ✨ 주요 기능

### 학생용 API
- **외박 신청 생성** (`POST /api/overnight-stay`)
  - 시작일, 종료일, 사유, 학기 정보를 받아 외박 신청 생성
  - 세션 정보에서 학번 자동 추출
  - 학기당 최대 3회 승인 제한 검증
  - 동시에 하나의 대기중 신청만 허용

- **내 외박 신청 목록 조회** (`GET /api/overnight-stay`)
  - 현재 학기 기준 외박 신청 목록 조회
  - 승인된 횟수 및 남은 횟수 포함된 요약 정보 제공

### 사감용 API
- **외박 신청 목록 조회** (`GET /api/overnight-stays`)
  - 페이지네이션 지원 (기본값: page=1, pageSize=10)
  - 학기(semester), 학번(studentIdNum) 필터링 지원
  - 학생 이름, 호실 번호 포함

- **외박 신청 승인/거부** (`PATCH /api/overnight-stays`)
  - 외박 신청 ID와 상태(approved/rejected)로 상태 변경
  - 상태 변경 시 해당 학생에게 푸시 알림 자동 발송

## 📁 변경된 파일

### 새로 추가된 파일
- `src/handlers/overnight_stays_handler.py` - 외박 관련 HTTP 핸들러
- `src/services/overnight_stays_service.py` - 외박 관련 비즈니스 로직
- `src/dto/overnight_stay_dto.py` - 외박 관련 DTO 클래스들

### 수정된 파일
- `src/utils/routing.py` - 외박 API 라우팅 규칙 추가
- `src/dto/__init__.py` - 외박 DTO 클래스 export 추가
- `docs/openapi.yml` - 외박 API 스펙 문서화 및 학생 API 경로 정리

## 🎯 API 엔드포인트

### 학생용
```
POST   /api/overnight-stay      - 외박 신청 생성
GET    /api/overnight-stay      - 내 외박 신청 목록 조회
```

### 사감용
```
GET    /api/overnight-stays     - 외박 신청 목록 조회 (페이지네이션, 필터링)
PATCH  /api/overnight-stays     - 외박 신청 승인/거부
```