### PR TITLE
feat: 구독 API를 PATCH로 변경하여 활성 상태 제어 기능 추가

### DIFF
--- a/docs/openapi.yml
+++ b/docs/openapi.yml
@@ -945,6 +945,48 @@ paths:
               schema:
                 $ref: "#/components/schemas/Error"
 
+    patch:
+      summary: FCM 구독 활성/비활성 상태 변경
+      description: |
+        로그인된 사용자의 모든 FCM 구독의 활성 상태를 변경합니다.
+        학번(student_no)은 세션 정보에서 자동으로 추출됩니다.
+        해당 학생의 모든 구독이 요청한 active 상태로 변경됩니다.
+      tags:
+        - Notifications
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/SubscriptionUpdateRequest"
+            example:
+              active: false
+      responses:
+        "200":
+          description: 구독 상태가 성공적으로 변경되었습니다.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SubscriptionUpdateResponse"
+        "400":
+          description: 잘못된 요청 (필수 필드 누락 또는 형식 오류)
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "401":
+          description: 인증 실패 (로그인 필요)
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "500":
+          description: 서버 내부 오류
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+
   /api/subscriptions/status:
     get:
       summary: FCM 구독 상태 조회
@@ -1831,6 +1873,38 @@ components:
           format: date-time
           description: 수정일시
           example: "2024-09-01T10:00:00Z"
+
+    SubscriptionUpdateRequest:
+      type: object
+      description: FCM 구독 상태 변경 요청
+      required:
+        - active
+      properties:
+        active:
+          type: boolean
+          description: 활성화 상태
+          example: false
+
+    SubscriptionUpdateResponse:
+      type: object
+      description: FCM 구독 상태 변경 응답
+      properties:
+        message:
+          type: string
+          description: 응답 메시지
+          example: "Subscription(s) updated successfully"
+        updated_count:
+          type: integer
+          description: 변경된 구독 개수
+          example: 2
+        student_no:
+          type: string
+          description: 학번
+          example: "20243105"
+        active:
+          type: boolean
+          description: 변경된 활성화 상태
+          example: false
 
     NotificationSendRequest:
       type: object

--- a/src/dto/__init__.py
+++ b/src/dto/__init__.py
@@ -25,6 +25,8 @@ from .calendar_dto import (
 from .notification_dto import (
     SubscriptionDTO,
     SubscriptionCreateRequestDTO,
+    SubscriptionUpdateRequestDTO,
+    SubscriptionUpdateResponseDTO,
     NotificationLogDTO,
 )
 from .overnight_stay_dto import (
@@ -60,6 +62,8 @@ __all__ = [
     "CalendarUpdateRequestDTO",
     "SubscriptionDTO",
     "SubscriptionCreateRequestDTO",
+    "SubscriptionUpdateRequestDTO",
+    "SubscriptionUpdateResponseDTO",
     "NotificationLogDTO",
     "OvernightStayDTO",
     "OvernightStayCreateRequestDTO",

--- a/src/dto/notification_dto.py
+++ b/src/dto/notification_dto.py
@@ -143,3 +143,26 @@ class PersonalNotificationLogDTO(BaseDTO):
             error_message=data.get("error_message"),
             sent_at=data.get("sent_at"),
         )
+
+
+@dataclass
+class SubscriptionUpdateRequestDTO(BaseDTO):
+    """FCM 구독 상태 변경 요청 DTO"""
+
+    active: bool
+
+    def validate(self) -> tuple[bool, Optional[str]]:
+        """요청 데이터 검증"""
+        if not isinstance(self.active, bool):
+            return False, "active must be a boolean value"
+        return True, None
+
+
+@dataclass
+class SubscriptionUpdateResponseDTO(BaseDTO):
+    """FCM 구독 상태 변경 응답 DTO"""
+
+    message: str
+    updated_count: int
+    student_no: str
+    active: bool

--- a/src/handlers/subscriptions_handler.py
+++ b/src/handlers/subscriptions_handler.py
@@ -8,8 +8,13 @@ from src.utils.responses import create_success_response, create_error_response
 from src.services.subscriptions_service import (
     create_subscription,
     get_subscription_status,
+    update_all_subscriptions_active_by_student_no,
 )
-from src.dto.notification_dto import SubscriptionCreateRequestDTO
+from src.dto.notification_dto import (
+    SubscriptionCreateRequestDTO,
+    SubscriptionUpdateRequestDTO,
+    SubscriptionUpdateResponseDTO,
+)
 
 # 로거 설정
 logger = logging.getLogger()
@@ -114,4 +119,85 @@ def get_subscription_status_handler(event, context):
 
     except Exception as e:
         logger.error(f"❌ 구독 상태 조회 핸들러 오류: {e}")
+        return create_error_response("Internal server error", 500)
+
+
+def patch_subscription_handler(event, context):
+    """
+    FCM 구독의 활성 상태를 변경합니다.
+
+    PATCH /subscriptions
+    Body: {
+        "active": true 또는 false
+    }
+    세션의 학번으로 모든 구독의 활성 상태를 변경합니다.
+    """
+    try:
+        logger.info("FCM 구독 상태 변경 요청 수신")
+
+        # 1. 세션에서 사용자 정보 추출
+        user_info = event.get("user_info", {})
+        username = user_info.get("username")
+
+        if not username:
+            logger.error("❌ 사용자 정보를 찾을 수 없습니다 (인증 필요)")
+            return create_error_response(
+                "Unauthorized: user information not found", 401
+            )
+
+        # 2. JSON 파싱
+        try:
+            body = json.loads(event.get("body", "{}"))
+        except json.JSONDecodeError:
+            logger.error("❌ 잘못된 JSON 형식")
+            return create_error_response("Invalid JSON format.", 400)
+
+        # 3. active 필드 확인
+        if "active" not in body:
+            logger.error("❌ active 필드가 누락되었습니다")
+            return create_error_response("active field is required", 400)
+
+        # 4. DTO 생성 및 검증
+        try:
+            request_dto = SubscriptionUpdateRequestDTO(
+                active=body.get("active"),
+            )
+        except Exception as e:
+            logger.error(f"❌ DTO 생성 실패: {e}")
+            return create_error_response(f"Invalid request data: {str(e)}", 400)
+
+        # 5. 데이터 검증
+        is_valid, error_msg = request_dto.validate()
+        if not is_valid:
+            logger.error(f"❌ 데이터 검증 실패: {error_msg}")
+            return create_error_response(error_msg, 400)
+
+        action = "활성화" if request_dto.active else "비활성화"
+        logger.info(f"📱 사용자 {username}의 모든 FCM 구독 {action} 요청")
+
+        # 6. 서비스 호출
+        updated_count, error = update_all_subscriptions_active_by_student_no(
+            username, request_dto.active
+        )
+
+        if error:
+            logger.error(f"❌ 구독 상태 변경 실패: {error}")
+            return create_error_response(error, 500)
+
+        # 7. DTO로 응답 생성
+        response_dto = SubscriptionUpdateResponseDTO(
+            message=f"Subscription(s) {'activated' if request_dto.active else 'deactivated'} successfully",
+            updated_count=updated_count,
+            student_no=username,
+            active=request_dto.active,
+        )
+
+        # 8. 성공 응답
+        logger.info(
+            f"✅ FCM 구독 상태 변경 완료: student_no={username}, updated_count={updated_count}, active={request_dto.active}"
+        )
+        return create_success_response(response_dto.to_dict())
+
+    except Exception as e:
+        logger.error(f"❌ 구독 상태 변경 핸들러 오류: {e}")
         return create_error_response("Internal server error", 500)

--- a/src/services/subscriptions_service.py
+++ b/src/services/subscriptions_service.py
@@ -162,3 +162,62 @@ def deactivate_invalid_subscription(subscription_id: int) -> Tuple[bool, Optiona
         logger.error(f"❌ 구독 비활성화 실패: {e}")
         error_message = getattr(e, "message", str(e))
         return False, error_message
+
+
+def update_all_subscriptions_active_by_student_no(
+    student_no: str,
+    active: bool,
+) -> Tuple[int, Optional[str]]:
+    """
+    특정 학생의 모든 구독의 활성 상태를 변경합니다.
+
+    Args:
+        student_no: 학번
+        active: 활성화 상태 (True: 활성화, False: 비활성화)
+
+    Returns:
+        (변경된 구독 개수, 에러 메시지)
+    """
+    try:
+        supabase = get_supabase_client("notify")
+        if not supabase:
+            return 0, "Supabase client could not be initialized."
+
+        action = "활성화" if active else "비활성화"
+        logger.info(f"학생 {student_no}의 모든 구독 {action} 시작")
+
+        # 해당 학번의 모든 구독 조회 (현재 상태와 관계없이)
+        select_response = (
+            supabase.postgrest.schema("notify")
+            .from_("subscriptions")
+            .select("id", count="exact")
+            .eq("student_no", student_no)
+            .execute()
+        )
+
+        total_count = select_response.count or 0
+
+        if total_count == 0:
+            logger.info(f"⚠️ 학생 {student_no}의 구독이 없습니다.")
+            return 0, None
+
+        # 현재 상태와 다른 구독만 업데이트
+        current_status = not active  # 반대 상태
+        update_response = (
+            supabase.postgrest.schema("notify")
+            .from_("subscriptions")
+            .update({"is_active": active})
+            .eq("student_no", student_no)
+            .eq("is_active", current_status)
+            .execute()
+        )
+
+        updated_count = len(update_response.data) if update_response.data else 0
+
+        logger.info(f"✅ 학생 {student_no}의 구독 {updated_count}개 {action} 완료")
+        return updated_count, None
+
+    except Exception as e:
+        logger.error(f"❌ 구독 상태 변경 실패: {e}")
+        error_message = getattr(e, "message", str(e))
+        return 0, error_message

--- a/src/utils/routing.py
+++ b/src/utils/routing.py
@@ -27,6 +27,10 @@ ROUTE_OVERRIDES: Dict[Tuple[str, str], Tuple[str, str]] = {
         "subscriptions_handler",
         "get_subscription_status_handler",
     ),
+    ("PATCH", "subscriptions"): (
+        "subscriptions_handler",
+        "patch_subscription_handler",
+    ),
     ("POST", "notifications"): (
         "notifications_handler",
         "send_notification_handler",


### PR DESCRIPTION
## 설명
구독 해제 API를 PATCH API로 변경하고, `active` 필드를 통해 구독을 활성화/비활성화할 수 있도록 개선했습니다.

## 주요 변경 사항
- `DELETE /api/subscriptions` → `PATCH /api/subscriptions`로 변경
- 요청 본문에 `active` 필드 추가 (true: 활성화, false: 비활성화)
- `SubscriptionUpdateRequestDTO`, `SubscriptionUpdateResponseDTO` 추가
- 구독 상태 변경 서비스 및 핸들러 함수 구현
- OpenAPI 스펙 업데이트


## 사용 예시
PATCH /api/subscriptions
```
{
  "active": false
}
```