### PR TITLE
feat: 관리비 사진 업로드, 조회 API 구현

### DIFF
--- a/docs/openapi.yml
+++ b/docs/openapi.yml
@@ -1143,7 +1143,7 @@ paths:
   /api/bill/presign:
     post:
       summary: 관리비 고지서 업로드 URL 발급
-      description: S3에 관리비 고지서 이미지를 업로드하기 위한 임시 presigned URL을 발급합니다. 발급된 URL은 5분간 유효합니다.
+      description: S3에 관리비 고지서 이미지를 업로드하기 위한 임시 presigned URL을 발급합니다. 발급된 URL은 5분간 유효합니다. 관리자가 요청할시 관리비 고지서 업로드 URL이 발급됩니다. 학생이 요청할시 관리비 납부 완료 업로드 URL이 발급됩니다.  
       tags:
         - Bills
       requestBody:
@@ -1188,10 +1188,10 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/Error"
-
+  
   /api/bill/image:
     get:
-      summary: 관리비 고지서 이미지 조회
+      summary:  관리비 고지서 이미지 조회, 관리자, 학생 조회 가능
       description: 저장된 관리비 고지서 이미지를 조회하기 위한 임시 다운로드 URL을 발급합니다. 발급된 URL은 5분간 유효합니다.
       tags:
         - Bills
@@ -1225,6 +1225,84 @@ paths:
           schema:
             type: string
           example: "9"
+      responses:
+        "200":
+          description: 이미지 정보가 성공적으로 반환되었습니다.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/BillImageResponse"
+        "400":
+          description: 잘못된 요청 (필수 쿼리 파라미터 누락 또는 유효하지 않은 값)
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+              examples:
+                missingParam:
+                  value:
+                    error: "roomId is required."
+                invalidType:
+                  value:
+                    error: "Invalid bill type. Must be one of: water, electricity, gas"
+        "404":
+          description: 이미지를 찾을 수 없음
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+              example:
+                error: "No image found for the specified criteria."
+        "500":
+          description: 서버 내부 오류
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+
+  /api/bill/paid/image:
+    get:
+      summary: 관리비 납부 완료 이미지 조회
+      description: 저장된 관리비 납부 완료 이미지를 조회하기 위한 임시 다운로드 URL을 발급합니다. 발급된 URL은 5분간 유효합니다. 관리자는 학번을 파라미터로 추가하여 학생 납부 완료 이미지를 조회할 수 있습니다. 학생은 학번 파라미터를 추가하지 않고 조회하면 자신의 납부 완료 이미지를 조회할 수 있습니다.
+      tags:
+        - Bills
+      parameters:
+        - name: roomId
+          in: query
+          description: 호실 번호
+          required: true
+          schema:
+            type: string
+          example: "101"
+        - name: type
+          in: query
+          description: 관리비 유형
+          required: true
+          schema:
+            type: string
+            enum: [water, electricity, gas]
+          example: "water"
+        - name: year
+          in: query
+          description: 연도
+          required: true
+          schema:
+            type: string
+          example: "2025"
+        - name: month
+          in: query
+          description: 월
+          required: true
+          schema:
+            type: string
+          example: "9"
+        - name: studentNo
+          in: query
+          description: 학생 번호
+          required: false
+          schema:
+            type: string
+            example: "20243105"
       responses:
         "200":
           description: 이미지 정보가 성공적으로 반환되었습니다.

--- a/src/handlers/bill_handler.py
+++ b/src/handlers/bill_handler.py
@@ -3,7 +3,12 @@ import logging
 
 from src.services import bill_service
 from src.utils import responses
-from src.utils.cognito_auth import is_admin_group, is_common_user_group
+from src.utils.cognito_auth import (
+    is_admin_group,
+    is_common_user_group,
+    is_admin_group_from_access_token,
+    is_common_user_group_from_access_token,
+)
 
 logger = logging.getLogger()
 logger.setLevel(logging.INFO)
@@ -26,7 +31,9 @@ def presign(event, context):
     logger.info("✅ Processing bill presign request")
 
     try:
-        if not is_admin_group(event.get("user_info")):
+        if not is_admin_group(event.get("user_info")) and not is_common_user_group(
+            event.get("user_info")
+        ):
             return responses.create_error_response("Unauthorized.", 401)
 
         body = json.loads(event.get("body", "{}"))
@@ -36,6 +43,7 @@ def presign(event, context):
         bill_type = body.get("type")
         year = body.get("year")
         month = body.get("month")
+        access_token = event.get("access_token") or ""
 
         # Validate required fields
         if not room_id:
@@ -46,9 +54,18 @@ def presign(event, context):
             return responses.create_error_response("year is required.", 400)
         if not month:
             return responses.create_error_response("month is required.", 400)
+        if not access_token:
+            return responses.create_error_response("access_token is required.", 400)
 
         data, err = bill_service.create_presigned_put_url(
-            content_type, file_ext, room_id, bill_type, year, month
+            content_type,
+            file_ext,
+            room_id,
+            bill_type,
+            year,
+            month,
+            event.get("user_info"),
+            access_token,
         )
         if err:
             return responses.create_error_response(err, 400)
@@ -84,7 +101,6 @@ def get_image(event, context):
         bill_type = query_params.get("type")
         year = query_params.get("year")
         month = query_params.get("month")
-        access_token = event.get("access_token") or ""
 
         # 필수 파라미터 검증
         if not room_id:
@@ -113,4 +129,65 @@ def get_image(event, context):
 
     except Exception as e:
         logger.error(f"❌ get bill image failed: {e}")
+        return responses.create_error_response("Internal server error.", 500)
+
+
+def get_paid_bill_image(event, context):
+    """
+    GET /bill/paid/image?roomId={roomId}&type={type}&year={year}&month={month}
+
+    Query Parameters:
+    - roomId: 방 번호 (필수)
+    - type: 관리비 유형 (water|electricity|gas) (필수)
+    - year: 연도 (필수)
+    - month: 월 (필수)
+    """
+    if not is_common_user_group(event.get("user_info")) and not is_admin_group(
+        event.get("user_info")
+    ):
+        return responses.create_error_response("Unauthorized.", 401)
+
+    logger.info("✅ Processing get paid bill image request")
+
+    try:
+        # 쿼리 파라미터 추출
+        query_params = event.get("queryStringParameters") or {}
+        room_id = query_params.get("roomId", False)
+        bill_type = query_params.get("type", False)
+        year = query_params.get("year", False)
+        month = query_params.get("month", False)
+        student_no = query_params.get("studentNo", False)
+
+        # 필수 파라미터 검증
+        if not room_id:
+            return responses.create_error_response("roomId is required.", 400)
+        if not bill_type or bill_type not in ["water", "electricity", "gas"]:
+            return responses.create_error_response(
+                "type is required, must be one of: water, electricity, gas", 400
+            )
+        if not year:
+            return responses.create_error_response("year is required.", 400)
+        if not month:
+            return responses.create_error_response("month is required.", 400)
+
+        if (
+            is_admin_group_from_access_token(event.get("access_token"))
+            and not student_no
+        ):
+            return responses.create_error_response("studentNo is required.", 400)
+
+        # 서비스 호출
+        data, error = bill_service.get_paid_bill_image(
+            room_id, bill_type, year, month, event.get("access_token")
+        )
+        if error:
+            return responses.create_error_response(error, 400)
+        if data is None:
+            return responses.create_error_response(
+                "No paid bill image found for the specified criteria.", 404
+            )
+
+        return responses.create_success_response(data)
+    except Exception as e:
+        logger.error(f"❌ get paid bill image failed: {e}")
         return responses.create_error_response("Internal server error.", 500)

--- a/src/services/bill_service.py
+++ b/src/services/bill_service.py
@@ -4,6 +4,13 @@ import uuid
 from typing import Any, Dict, Tuple
 from datetime import datetime
 import boto3
+from src.utils.cognito_auth import (
+    get_user_info,
+    is_admin_group,
+    is_common_user_group,
+    is_admin_group_from_access_token,
+    is_common_user_group_from_access_token,
+)
 
 S3 = boto3.client("s3")
 
@@ -23,17 +30,43 @@ def _load_env() -> Tuple[str, set[str], int, str, str]:
             "image/svg+xml",
         }
         expires = 300
-        if is_admin_group(user_info):
-            key_prefix = "bills"
-        elif is_common_user_group(user_info):
-            key_prefix = "paid"
-        elif user_info.get("token_use") == "default":
-            key_prefix = "bills"
-        else:
-            raise Exception("Unauthorized")
 
         allow_origin = "*"
-        return bucket, allowed, expires, key_prefix, allow_origin
+        return bucket, allowed, expires, allow_origin
+    except Exception as e:
+        raise e
+
+
+def _get_key_prefix_to_upload(
+    access_token: str, year: str, month: str, room_id: str, bill_type: str
+) -> str:
+    try:
+        user_info = get_user_info(access_token)
+        user_name = user_info.get("username")
+        user_groups = user_info.get("groups")
+        if "admin" in user_groups:
+            return f"bills/{year}/{month}/{room_id}/{bill_type}"
+        elif "common_user" in user_groups:
+            return f"paid/{year}/{month}/{room_id}/{bill_type}/{user_name}"
+    except Exception as e:
+        raise e
+
+
+def _get_paid_key_prefix(
+    access_token: str,
+    year: str,
+    month: str,
+    room_id: str,
+    bill_type: str,
+    student_no: str = False,
+) -> str:
+    try:
+        if student_no is not False:
+            return f"paid/{year}/{month}/{room_id}/{student_no}/{bill_type}"
+        else:
+            user_info = get_user_info(access_token)
+            user_name = user_info.get("username")
+            return f"paid/{year}/{month}/{room_id}/{user_name}/{bill_type}"
     except Exception as e:
         raise e
 
@@ -45,9 +78,11 @@ def create_presigned_put_url(
     bill_type: str,
     year: str,
     month: str,
+    user_info: Dict[str, Any],
+    access_token: str,
 ) -> Tuple[Dict[str, Any] | None, str | None]:
     try:
-        bucket, allowed, expires, key_prefix, allow_origin = _load_env()
+        bucket, allowed, expires, allow_origin = _load_env()
 
         if allowed and content_type not in allowed:
             return None, f"contentType '{content_type}' not allowed"
@@ -58,7 +93,7 @@ def create_presigned_put_url(
             return None, f"Invalid bill type. Must be one of: {', '.join(valid_types)}"
 
         # Create S3 key with roomId and type: bills/{roomId}/{type}
-        key = f"{key_prefix}/{year}/{month}/{room_id}/{bill_type}"
+        key = _get_key_prefix_to_upload(access_token, year, month, room_id, bill_type)
 
         url = S3.generate_presigned_url(
             ClientMethod="put_object",
@@ -96,9 +131,10 @@ def get_bill_image(
         Tuple[Dict, str | None]: (이미지 데이터, 에러 메시지)
     """
     try:
-        bucket, allowed, expires, key_prefix, allow_origin = _load_env()
+        bucket, allowed, expires, allow_origin = _load_env()
 
         # S3 prefix 생성: bills/{year}/{month}/{room_id}/{bill_type} (파일명으로 사용)
+        key_prefix = "bills"
         prefix = f"{key_prefix}/{year}/{month}/{room_id}/{bill_type}"
 
         # S3에서 객체 목록 조회
@@ -132,12 +168,23 @@ def get_bill_image(
 
 
 def get_paid_bill_image(
-    room_id: str, bill_type: str, year: str, month: str
+    room_id: str,
+    bill_type: str,
+    year: str,
+    month: str,
+    access_token: str,
+    student_no: str = "",
 ) -> Tuple[Dict[str, Any] | None, str | None]:
     try:
-        bucket, allowed, expires, key_prefix, allow_origin = _load_env()
-        key_prefix = "paid"
-        prefix = f"{key_prefix}/{year}/{month}/{room_id}/{bill_type}"
+        bucket, allowed, expires, allow_origin = _load_env()
+
+        if is_admin_group_from_access_token(access_token):
+            prefix = _get_paid_key_prefix(
+                access_token, year, month, room_id, bill_type, student_no
+            )
+        elif is_common_user_group_from_access_token(access_token):
+            prefix = _get_paid_key_prefix(access_token, year, month, room_id, bill_type)
+        print(prefix)
         response = S3.list_objects_v2(Bucket=bucket, Prefix=prefix)
         if "Contents" in response and len(response["Contents"]) > 0:
             obj = response["Contents"][0]

--- a/src/utils/cognito_auth.py
+++ b/src/utils/cognito_auth.py
@@ -111,3 +111,16 @@ def is_common_user_group(user_info: Dict[str, Any]) -> bool:
 
 def is_admin_group(user_info: Dict[str, Any]) -> bool:
     return "admin" in user_info.get("groups") and user_info.get("token_use") == "access"
+
+
+def is_admin_group_from_access_token(access_token: str) -> bool:
+    user_info = get_user_info(access_token)
+    return "admin" in user_info.get("groups") and user_info.get("token_use") == "access"
+
+
+def is_common_user_group_from_access_token(access_token: str) -> bool:
+    user_info = get_user_info(access_token)
+    return (
+        "common_user" in user_info.get("groups")
+        and user_info.get("token_use") == "access"
+    )

--- a/src/utils/routing.py
+++ b/src/utils/routing.py
@@ -22,6 +22,7 @@ ROUTE_OVERRIDES: Dict[Tuple[str, str], Tuple[str, str]] = {
     ("GET", "student"): ("students_handler", "get_by_student_no"),
     ("POST", "bill/presign"): ("bill_handler", "presign"),
     ("GET", "bill/image"): ("bill_handler", "get_image"),
+    ("GET", "bill/paid/image"): ("bill_handler", "get_paid_bill_image"),
     ("POST", "subscriptions"): ("subscriptions_handler", "create_subscription_handler"),
     ("GET", "subscriptions/status"): (
         "subscriptions_handler",


### PR DESCRIPTION
- /bill/presign 관리자가 요청할시 관리비 사진을 업로드 가능한 URL이 발급됩니다. 학생이 요청할시 관리비 납부 완료 사진을 업로드 가능한 URL이 발급됩니다.
- /bill/image 관리비 사진을 조회합니다. 학생, 관리자가 로그인 상태일때 조회가능합니다.
- /bill/paid/image 관리비 납부 완료한 이미지를 조회합니다. 관리자는 학번을 파라미터로 입력하여 해당 학번이 납부완료한 사진을 조회 가능합니다. 학생은 학번 파라미터를 입력하지 않고 조회하면 자신의 관리비 납부 완료 사진을 조회 할 수 있습니다.