### PR TITLE
feat: 고정공지 개수 제한 검증 및 응답 처리 개선

### DIFF
--- a/src/handlers/notices_handler.py
+++ b/src/handlers/notices_handler.py
@@ -71,6 +71,9 @@ def create(event, context):
         )
 
         if error:
+            # 고정공지 개수 제한 에러는 400 Bad Request
+            if "Maximum 10 pinned notices" in error:
+                return responses.create_error_response(error, 400)
             return responses.create_error_response(error, 500)
 
         # DTO를 사용하여 응답 데이터 변환
@@ -201,6 +204,9 @@ def update(event, context):
         if error:
             if error == "Notice not found":
                 return responses.create_error_response(error, 404)
+            # 고정공지 개수 제한 에러는 400 Bad Request
+            if "Maximum 10 pinned notices" in error:
+                return responses.create_error_response(error, 400)
             return responses.create_error_response(error, 500)
 
         # DTO를 사용하여 응답 데이터 변환

--- a/src/services/notices_service.py
+++ b/src/services/notices_service.py
@@ -8,6 +8,51 @@ logger = logging.getLogger()
 logger.setLevel(logging.INFO)
 
 
+def check_pinned_notices_limit(is_important: bool, notice_id: Optional[int] = None) -> tuple[bool, Optional[str]]:
+    """
+    고정공지 개수 제한 검증 (최대 10개)
+    
+    Args:
+        is_important: 고정공지로 설정하려는지 여부
+        notice_id: 수정 시 자기 자신의 ID (생성 시에는 None)
+    
+    Returns:
+        (is_valid, error_message)
+    """
+    if not is_important:
+        return True, None
+    
+    try:
+        supabase = get_supabase_client("core")
+        if not supabase:
+            return False, "Supabase client could not be initialized."
+        
+        # 현재 고정공지 개수 조회
+        query = (
+            supabase.postgrest.schema("core")
+            .from_("notice")
+            .select("id", count="exact")
+            .eq("status", "PUBLISHED")
+            .eq("is_important", True)
+        )
+        
+        # 수정 시에는 자기 자신 제외
+        if notice_id:
+            query = query.neq("id", notice_id)
+        
+        response = query.execute()
+        current_count = response.count if response.count is not None else 0
+        
+        if current_count >= 10:
+            return False, "Maximum 10 pinned notices allowed. Please unpin another notice first."
+        
+        return True, None
+    
+    except Exception as e:
+        logger.error(f"❌ 고정공지 개수 검증 실패: {e}")
+        return False, "Failed to validate pinned notices limit"
+
+
 def get_notice_by_id(notice_id: str):
     """
     Supabase 클라이언트를 사용하여 특정 공지사항을 가져옵니다.
@@ -50,6 +95,12 @@ def create_notice(
     Supabase 클라이언트를 사용하여 새로운 공지사항을 생성합니다.
     """
     try:
+        # 고정공지 개수 검증 (애플리케이션 레벨)
+        if is_important:
+            is_valid, error_message = check_pinned_notices_limit(is_important)
+            if not is_valid:
+                return None, error_message
+
         supabase = get_supabase_client("core")
         if not supabase:
             return None, "Supabase client could not be initialized."
@@ -85,13 +136,17 @@ def create_notice(
     except Exception as e:
         logger.error(f"❌ Supabase API 호출 실패: {e}")
         error_message = getattr(e, "message", str(e))
+        # DB 제약 조건 에러 메시지 확인
+        if "Maximum 10 pinned notices" in str(error_message):
+            return None, "Maximum 10 pinned notices allowed. Please unpin another notice first."
         return None, error_message
 
 
 def get_notices_with_pagination(page: int = 1):
     """
     Supabase 클라이언트를 사용하여 페이지네이션된 공지사항을 가져옵니다.
-    페이지당 10개의 공지사항을 반환합니다.
+    - 1페이지: 고정공지 N개 + 일반공지 (10-N)개
+    - 2페이지부터: 일반공지만
 
     Returns:
         tuple: (notices_data, total_count, page_size, error)
@@ -107,30 +162,71 @@ def get_notices_with_pagination(page: int = 1):
             f"Supabase 'notice' 테이블 페이지네이션 조회 시작 - 페이지: {page}, 크기: {PAGE_SIZE}"
         )
 
-        # 페이지네이션 계산
-        offset = (page - 1) * PAGE_SIZE
-
-        # 단일 쿼리로 데이터와 전체 개수를 함께 조회 (성능 최적화)
-        response = (
-            supabase.postgrest.schema("core")
-            .from_("notice")
-            .select(
-                "id, title, content, created_at, is_important, status", count="exact"
+        if page == 1:
+            # 1페이지: 고정공지 + 일반공지
+            # 1) 고정공지 조회
+            pinned_response = (
+                supabase.postgrest.schema("core")
+                .from_("notice")
+                .select("id, title, content, created_at, is_important, status")
+                .eq("status", "PUBLISHED")
+                .eq("is_important", True)
+                .order("created_at", desc=True)
+                .execute()
             )
-            .eq("status", "PUBLISHED")
-            .order("created_at", desc=True)
-            .range(offset, offset + PAGE_SIZE - 1)
-            .execute()
-        )
-
-        notices_data = response.data
-        total_count = response.count if response.count is not None else 0
-        logger.info(
-            f"✅ Supabase로부터 페이지 {page}의 {len(notices_data)}개 공지사항을 성공적으로 가져왔습니다. (전체: {total_count}개)"
-        )
-
-        # 원시 데이터와 페이지 크기 정보를 반환 (DTO 변환은 핸들러에서 처리)
-        return notices_data, total_count, PAGE_SIZE, None
+            
+            pinned_notices = pinned_response.data
+            pinned_count = len(pinned_notices)
+            
+            # 2) 일반공지 조회 (나머지 개수만큼)
+            normal_count = PAGE_SIZE - pinned_count
+            normal_response = (
+                supabase.postgrest.schema("core")
+                .from_("notice")
+                .select("id, title, content, created_at, is_important, status", count="exact")
+                .eq("status", "PUBLISHED")
+                .eq("is_important", False)
+                .order("created_at", desc=True)
+                .limit(normal_count)
+                .execute()
+            )
+            
+            # 3) 합치기: 고정공지 + 일반공지
+            all_notices = pinned_notices + normal_response.data
+            
+            # 4) 페이지 정보 (일반공지 기준)
+            total_count = normal_response.count if normal_response.count is not None else 0
+            
+            logger.info(
+                f"✅ Supabase로부터 페이지 {page}의 {len(all_notices)}개 공지사항을 성공적으로 가져왔습니다. (고정공지: {pinned_count}개, 일반공지: {len(normal_response.data)}개, 전체 일반공지: {total_count}개)"
+            )
+            
+            return all_notices, total_count, PAGE_SIZE, None
+        
+        else:
+            # 2페이지부터: 일반공지만
+            offset = (page - 1) * PAGE_SIZE
+            response = (
+                supabase.postgrest.schema("core")
+                .from_("notice")
+                .select(
+                    "id, title, content, created_at, is_important, status", count="exact"
+                )
+                .eq("status", "PUBLISHED")
+                .eq("is_important", False)
+                .order("created_at", desc=True)
+                .range(offset, offset + PAGE_SIZE - 1)
+                .execute()
+            )
+            
+            notices_data = response.data
+            total_count = response.count if response.count is not None else 0
+            
+            logger.info(
+                f"✅ Supabase로부터 페이지 {page}의 {len(notices_data)}개 공지사항을 성공적으로 가져왔습니다. (전체 일반공지: {total_count}개)"
+            )
+            
+            return notices_data, total_count, PAGE_SIZE, None
 
     except Exception as e:
         logger.error(f"❌ Supabase API 호출 실패: {e}")
@@ -206,6 +302,12 @@ def update_notice_by_id(
     Supabase 클라이언트를 사용하여 특정 공지사항을 수정합니다.
     """
     try:
+        # 고정공지로 변경하려는 경우 검증 (애플리케이션 레벨)
+        if is_important:
+            is_valid, error_message = check_pinned_notices_limit(is_important, notice_id)
+            if not is_valid:
+                return None, error_message
+
         supabase = get_supabase_client("core")
         if not supabase:
             return None, "Supabase client could not be initialized."
@@ -239,6 +341,9 @@ def update_notice_by_id(
     except Exception as e:
         logger.error(f"❌ Supabase API 호출 실패: {e}")
         error_message = getattr(e, "message", str(e))
+        # DB 제약 조건 에러 메시지 확인
+        if "Maximum 10 pinned notices" in str(error_message):
+            return None, "Maximum 10 pinned notices allowed. Please unpin another notice first."
         return None, error_message
 
 
@@ -256,7 +361,8 @@ def get_notices_with_filters(
 ):
     """
     Supabase 클라이언트를 사용하여 필터링 및 검색된 공지사항을 가져옵니다.
-    페이지당 10개의 공지사항을 반환합니다.
+    - 1페이지: 고정공지 N개 + 일반공지 (10-N)개 (필터 적용 시에도 동일)
+    - 2페이지부터: 일반공지만
 
     Returns:
         tuple: (notices_data, total_count, page_size, error)
@@ -272,73 +378,142 @@ def get_notices_with_filters(
             f"Supabase 'notice' 테이블 필터링 조회 시작 - 페이지: {page}, 크기: {PAGE_SIZE}"
         )
 
-        # 페이지네이션 계산
-        offset = (page - 1) * PAGE_SIZE
-
-        # 쿼리 빌더 시작
-        query = (
-            supabase.postgrest.schema("core")
-            .from_("notice")
-            .select(
-                "id, title, content, created_at, is_important, status", count="exact"
+        if page == 1:
+            # 1페이지: 고정공지 + 일반공지
+            # 1) 고정공지 조회 (필터 적용)
+            pinned_query = (
+                supabase.postgrest.schema("core")
+                .from_("notice")
+                .select("id, title, content, created_at, is_important, status")
+                .eq("status", "PUBLISHED")
+                .eq("is_important", True)
             )
-        )
-
-        # 검색 필터링 (title 또는 content에 검색어 포함)
-        if search:
-            # ILIKE를 사용한 부분 문자열 검색 (대소문자 무시)
-            search_pattern = f"%{search}%"
-            query = query.or_(
-                f"title.ilike.{search_pattern},content.ilike.{search_pattern}"
+            
+            # 검색 필터링
+            if search:
+                search_pattern = f"%{search}%"
+                pinned_query = pinned_query.or_(
+                    f"title.ilike.{search_pattern},content.ilike.{search_pattern}"
+                )
+            
+            # 날짜 필터링
+            if start_date and end_date:
+                pinned_query = pinned_query.gte("created_at", start_date).lte("created_at", end_date)
+            elif year is not None and month is not None and day is not None:
+                single_date_start = f"{year:04d}-{month:02d}-{day:02d}T00:00:00"
+                single_date_end = f"{year:04d}-{month:02d}-{day:02d}T23:59:59"
+                pinned_query = pinned_query.gte("created_at", single_date_start).lte("created_at", single_date_end)
+            
+            # 정렬
+            if sort == "oldest":
+                pinned_query = pinned_query.order("created_at", desc=False)
+            else:
+                pinned_query = pinned_query.order("created_at", desc=True)
+            
+            pinned_response = pinned_query.execute()
+            pinned_notices = pinned_response.data
+            pinned_count = len(pinned_notices)
+            
+            # 2) 일반공지 조회 (나머지 개수만큼, 필터 적용)
+            normal_count = PAGE_SIZE - pinned_count
+            normal_query = (
+                supabase.postgrest.schema("core")
+                .from_("notice")
+                .select("id, title, content, created_at, is_important, status", count="exact")
+                .eq("status", "PUBLISHED")
+                .eq("is_important", False)
             )
-            logger.info(f"검색어 적용: {search}")
-
-        # status 필터링 (여러 개 선택 가능, OR 조건)
-        if status is not None and len(status) > 0:
-            query = query.in_("status", status)
-            logger.info(f"Status 필터 적용: {status}")
-
-        # is_important 필터링
-        if is_important is not None:
-            query = query.eq("is_important", is_important)
-            logger.info(f"Is_important 필터 적용: {is_important}")
-
-        # 날짜 필터링
-        if start_date and end_date:
-            # 범위 필터링
-            query = query.gte("created_at", start_date).lte("created_at", end_date)
-            logger.info(f"날짜 범위 필터 적용: {start_date} ~ {end_date}")
-        elif year is not None and month is not None and day is not None:
-            # 단일 날짜 필터링 (해당 날짜의 00:00:00 ~ 23:59:59)
-            single_date_start = f"{year:04d}-{month:02d}-{day:02d}T00:00:00"
-            single_date_end = f"{year:04d}-{month:02d}-{day:02d}T23:59:59"
-            query = query.gte("created_at", single_date_start).lte(
-                "created_at", single_date_end
+            
+            # 검색 필터링
+            if search:
+                search_pattern = f"%{search}%"
+                normal_query = normal_query.or_(
+                    f"title.ilike.{search_pattern},content.ilike.{search_pattern}"
+                )
+            
+            # 날짜 필터링
+            if start_date and end_date:
+                normal_query = normal_query.gte("created_at", start_date).lte("created_at", end_date)
+            elif year is not None and month is not None and day is not None:
+                single_date_start = f"{year:04d}-{month:02d}-{day:02d}T00:00:00"
+                single_date_end = f"{year:04d}-{month:02d}-{day:02d}T23:59:59"
+                normal_query = normal_query.gte("created_at", single_date_start).lte("created_at", single_date_end)
+            
+            # 정렬
+            if sort == "oldest":
+                normal_query = normal_query.order("created_at", desc=False)
+            else:
+                normal_query = normal_query.order("created_at", desc=True)
+            
+            normal_query = normal_query.limit(normal_count)
+            normal_response = normal_query.execute()
+            
+            # 3) 합치기: 고정공지 + 일반공지
+            all_notices = pinned_notices + normal_response.data
+            
+            # 4) 페이지 정보 (일반공지 기준)
+            total_count = normal_response.count if normal_response.count is not None else 0
+            
+            logger.info(
+                f"✅ Supabase로부터 필터링된 페이지 {page}의 {len(all_notices)}개 공지사항을 성공적으로 가져왔습니다. (고정공지: {pinned_count}개, 일반공지: {len(normal_response.data)}개, 전체 일반공지: {total_count}개)"
             )
-            logger.info(f"단일 날짜 필터 적용: {year}-{month:02d}-{day:02d}")
-
-        # 정렬
-        if sort == "oldest":
-            query = query.order("created_at", desc=False)
-            logger.info("정렬: 오래된순 (created_at ASC)")
+            
+            return all_notices, total_count, PAGE_SIZE, None
+        
         else:
-            query = query.order("created_at", desc=True)
-            logger.info("정렬: 최신순 (created_at DESC)")
-
-        # 페이지네이션 적용
-        query = query.range(offset, offset + PAGE_SIZE - 1)
-
-        # 쿼리 실행
-        response = query.execute()
-
-        notices_data = response.data
-        total_count = response.count if response.count is not None else 0
-        logger.info(
-            f"✅ Supabase로부터 필터링된 페이지 {page}의 {len(notices_data)}개 공지사항을 성공적으로 가져왔습니다. (전체: {total_count}개)"
-        )
-
-        # 원시 데이터와 페이지 크기 정보를 반환 (DTO 변환은 핸들러에서 처리)
-        return notices_data, total_count, PAGE_SIZE, None
+            # 2페이지부터: 일반공지만 (필터 적용)
+            offset = (page - 1) * PAGE_SIZE
+            
+            query = (
+                supabase.postgrest.schema("core")
+                .from_("notice")
+                .select(
+                    "id, title, content, created_at, is_important, status", count="exact"
+                )
+                .eq("status", "PUBLISHED")
+                .eq("is_important", False)
+            )
+            
+            # 검색 필터링
+            if search:
+                search_pattern = f"%{search}%"
+                query = query.or_(
+                    f"title.ilike.{search_pattern},content.ilike.{search_pattern}"
+                )
+                logger.info(f"검색어 적용: {search}")
+            
+            # 날짜 필터링
+            if start_date and end_date:
+                query = query.gte("created_at", start_date).lte("created_at", end_date)
+                logger.info(f"날짜 범위 필터 적용: {start_date} ~ {end_date}")
+            elif year is not None and month is not None and day is not None:
+                single_date_start = f"{year:04d}-{month:02d}-{day:02d}T00:00:00"
+                single_date_end = f"{year:04d}-{month:02d}-{day:02d}T23:59:59"
+                query = query.gte("created_at", single_date_start).lte("created_at", single_date_end)
+                logger.info(f"단일 날짜 필터 적용: {year}-{month:02d}-{day:02d}")
+            
+            # 정렬
+            if sort == "oldest":
+                query = query.order("created_at", desc=False)
+                logger.info("정렬: 오래된순 (created_at ASC)")
+            else:
+                query = query.order("created_at", desc=True)
+                logger.info("정렬: 최신순 (created_at DESC)")
+            
+            # 페이지네이션 적용
+            query = query.range(offset, offset + PAGE_SIZE - 1)
+            
+            # 쿼리 실행
+            response = query.execute()
+            
+            notices_data = response.data
+            total_count = response.count if response.count is not None else 0
+            
+            logger.info(
+                f"✅ Supabase로부터 필터링된 페이지 {page}의 {len(notices_data)}개 공지사항을 성공적으로 가져왔습니다. (전체 일반공지: {total_count}개)"
+            )
+            
+            return notices_data, total_count, PAGE_SIZE, None
 
     except Exception as e:
         logger.error(f"❌ Supabase API 호출 실패: {e}")


### PR DESCRIPTION
### 작업 내용

- **`is_important`** 값을 상단 고정공지 용으로 사용
- 고정공지 개수를 10개로 제한하고, **`PUBLISHED`** 값에만 개수 제한 적용
- 페이지네이션 로직 개선: 고정공지와 일반공지를 분리하여 처리
- 필터링 로직 조정: 검색 결과에서도 고정공지 개수 제한 유지