### PR TITLE
fix: 관리비 업데이트 api 수정

### DIFF
--- a/docs/openapi.yml
+++ b/docs/openapi.yml
@@ -1191,7 +1191,7 @@ paths:
   /api/bill:
     patch:
       summary: 관리비 수정
-      description: 관리비를 수정합니다. 학생 번호와 관리비 유형을 파라미터로 추가하여 학생의 관리비의 type,amount,bankInfo,endDate를 부분적으로 수정할 수 있습니다.
+      description: 관리비를 수정합니다. 관리비 유형(`type`)은 필수이며, `amount`, `bankInfo`, `endDate`, `is_paid`는 선택적으로 부분 수정할 수 있습니다. 관리자는 학생 번호(`studentNo`)를 body에 추가하여 학생의 관리비를 수정할 수 있습니다. 학생은 학생 번호(`studentNo`)를 body에 추가하지 않고 조회하면 자신의 관리비를 수정할 수 있습니다. 또한 학생은 요청 본문에 `type`과 `is_paid`만 포함하여 본인의 납부 상태(`is_paid`)만 수정할 수 있습니다.
       tags:
         - Bills
       requestBody:
@@ -1201,7 +1201,6 @@ paths:
             schema:
               type: object
               required:
-                - studentNo
                 - type
               properties:
                 studentNo:
@@ -1232,7 +1231,7 @@ paths:
                   format: date
                   description: 납부 마감일 (YYYY-MM-DD)
                   example: "2025-11-30"
-                admin_check:
+                is_paid:
                   type: boolean
                   description: 관리자 확인 여부
                   example: true
@@ -1242,6 +1241,7 @@ paths:
               amount: 100000
               bankInfo: [{ bank: "국민", account: "123456789012" }]
               endDate: "2025-11-30"
+              is_paid: true
       responses:
         "200":
           description: 관리비가 성공적으로 수정되었습니다. true를 반환합니다.

--- a/src/handlers/bill_handler.py
+++ b/src/handlers/bill_handler.py
@@ -237,22 +237,24 @@ def update_bill(event, context):
       "amount": 12345,               # optional
       "bankInfo": [ { ... } ],       # optional, list of objects
       "endDate": "2025-11-30"        # optional, YYYY-MM-DD
-      "admin_check": true             # optional, true if the bill is checked by admin
+      "is_paid": true             # optional, true if the bill is checked by admin
     }
     """
-    if not is_admin_group(event.get("user_info")):
+    if not is_admin_group(event.get("user_info")) and not is_common_user_group(
+        event.get("user_info")
+    ):
         return responses.create_error_response("Unauthorized.", 401)
 
     try:
         body = json.loads(event.get("body", "{}"))
-        student_no = body.get("studentNo")
+        student_no = body.get("studentNo", None)
         bill_type = body.get("type")
         amount = body.get("amount", None)
         bank_info = body.get("bankInfo", None)
         end_date = body.get("endDate", None)
-        admin_check = body.get("admin_check", None)
+        is_paid = body.get("is_paid", None)
         # required checks
-        if not student_no:
+        if is_admin_group(event.get("user_info")) and not student_no:
             return responses.create_error_response("studentNo is required.", 400)
         if not bill_type or bill_type not in ["water", "electricity", "gas"]:
             return responses.create_error_response(
@@ -267,19 +269,20 @@ def update_bill(event, context):
             update_payload["bank_info"] = bank_info
         if end_date is not None:
             update_payload["end_date"] = end_date
-        if admin_check is not None:
-            update_payload["admin_check"] = admin_check
+        if is_paid is not None:
+            update_payload["is_paid"] = is_paid
 
         if not update_payload:
             return responses.create_error_response(
-                "At least one of amount, bankInfo, endDate, admin_check is required.",
+                "At least one of amount, bankInfo, endDate, is_paid is required.",
                 400,
             )
 
-        success, error = bill_service.update_bill_from_student_no(
+        success, error = bill_service.update_bill(
             student_no=student_no,
             bill_data=update_payload,
             bill_type=bill_type,
+            access_token=event.get("access_token"),
         )
 
         if not success:

--- a/src/services/bill_service.py
+++ b/src/services/bill_service.py
@@ -245,15 +245,20 @@ def get_bill(
         return None, str(e)
 
 
-def update_bill_from_student_no(
-    student_no: str,
+def update_bill(
+    student_no: str | None,
     bill_data: Dict[str, Any],
     bill_type: str,
+    access_token: str,
 ) -> Tuple[Dict[str, Any] | None, str | None]:
     """
     Supabase에서 studentNo로 단일 학생의 관리비를 수정합니다.
     """
     try:
+        if student_no is None:
+            student_no = get_user_info(access_token).get("username")
+            bill_data = {"is_paid": bill_data["is_paid"]}
+
         supabase = get_supabase_client("core")
 
         response = (


### PR DESCRIPTION
- 관리비를 수정합니다. 관리비 유형(type)은 필수이며, amount, bankInfo, endDate, is_paid는 선택적으로 부분 수정할 수 있습니다. 관리자는 학생 번호(studentNo)를 body에 추가하여 학생의 관리비를 수정할 수 있습니다. 학생은 학생 번호(studentNo)를 body에 추가하지 않고 조회하면 자신의 관리비를 수정할 수 있습니다. 또한 학생은 요청 본문에 type과 is_paid만 포함하여 본인의 납부 상태(is_paid)만 수정할 수 있습니다.