### PR TITLE
feat: 점호 기능 및 상벌점 부여 기능 추가

### DIFF
--- a/docs/openapi.yml
+++ b/docs/openapi.yml
@@ -1143,7 +1143,7 @@ paths:
   /api/bill/presign:
     post:
       summary: 관리비 고지서 업로드 URL 발급
-      description: S3에 관리비 고지서 이미지를 업로드하기 위한 임시 presigned URL을 발급합니다. 발급된 URL은 5분간 유효합니다. 관리자가 요청할시 관리비 고지서 업로드 URL이 발급됩니다. 학생이 요청할시 관리비 납부 완료 업로드 URL이 발급됩니다.  
+      description: S3에 관리비 고지서 이미지를 업로드하기 위한 임시 presigned URL을 발급합니다. 발급된 URL은 5분간 유효합니다. 관리자가 요청할시 관리비 고지서 업로드 URL이 발급됩니다. 학생이 요청할시 관리비 납부 완료 업로드 URL이 발급됩니다.
       tags:
         - Bills
       requestBody:
@@ -1357,7 +1357,7 @@ paths:
                 $ref: "#/components/schemas/Error"
   /api/bill/image:
     get:
-      summary:  관리비 고지서 이미지 조회, 관리자, 학생 조회 가능
+      summary: 관리비 고지서 이미지 조회, 관리자, 학생 조회 가능
       description: 저장된 관리비 고지서 이미지를 조회하기 위한 임시 다운로드 URL을 발급합니다. 발급된 URL은 5분간 유효합니다.
       tags:
         - Bills
@@ -1503,7 +1503,6 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/Error"
- 
 
   /auth/login:
     get:
@@ -1544,6 +1543,324 @@ paths:
           description: 로그인 완료 후 최종 리다이렉트
         "400":
           description: state/code 오류
+
+  /api/rollcalls:
+    get:
+      summary: 점호 기록 조회
+      description: 필터링된 점호 기록을 조회합니다. 날짜, 호실, 학생 이름, 출석 여부로 필터링할 수 있습니다.
+      tags:
+        - Rollcalls
+      parameters:
+        - name: date
+          in: query
+          description: 점호 날짜 (YYYY-MM-DD 형식)
+          required: false
+          schema:
+            type: string
+            format: date
+          example: "2025-11-16"
+        - name: roomId
+          in: query
+          description: 호실 번호
+          required: false
+          schema:
+            type: integer
+          example: 101
+        - name: name
+          in: query
+          description: 학생 이름 (부분 일치)
+          required: false
+          schema:
+            type: string
+          example: "홍길동"
+        - name: present
+          in: query
+          description: 출석 여부 (true=출석만, false=결석만)
+          required: false
+          schema:
+            type: boolean
+          example: true
+      responses:
+        "200":
+          description: 성공적으로 점호 기록을 반환했습니다.
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/Rollcall"
+        "400":
+          description: 잘못된 요청 (파라미터 형식 오류)
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "500":
+          description: 서버 내부 오류
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+
+  /api/rollcall:
+    post:
+      summary: 점호 기록 생성/수정 (Upsert)
+      description: 점호 기록을 생성하거나 수정합니다. 같은 학생의 같은 날짜에 이미 기록이 있으면 수정하고, 없으면 생성합니다.
+      tags:
+        - Rollcalls
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/RollcallCreateRequest"
+            example:
+              studentId: "20240001"
+              date: "2025-11-16"
+              present: true
+              note: "사감실 확인"
+      responses:
+        "200":
+          description: 점호 기록이 성공적으로 생성/수정되었습니다.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Rollcall"
+        "400":
+          description: 잘못된 요청 (필수 필드 누락 또는 형식 오류)
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "404":
+          description: 학생을 찾을 수 없음
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "500":
+          description: 서버 내부 오류
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+
+    patch:
+      summary: 점호 기록 부분 수정
+      description: 점호 기록의 출석 여부나 비고를 부분 수정합니다.
+      tags:
+        - Rollcalls
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/RollcallUpdateRequest"
+            example:
+              id: 1
+              present: false
+              note: "병가로 변경"
+      responses:
+        "200":
+          description: 점호 기록이 성공적으로 수정되었습니다.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Rollcall"
+        "400":
+          description: 잘못된 요청 (ID 형식 오류 또는 필수 필드 누락)
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "404":
+          description: 점호 기록을 찾을 수 없음
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "500":
+          description: 서버 내부 오류
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+
+    delete:
+      summary: 점호 기록 삭제
+      description: 특정 점호 기록을 삭제합니다.
+      tags:
+        - Rollcalls
+      parameters:
+        - name: id
+          in: query
+          description: 삭제할 점호 기록 ID
+          required: true
+          schema:
+            type: integer
+          example: 1
+      responses:
+        "200":
+          description: 점호 기록이 성공적으로 삭제되었습니다.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                    example: "Rollcall deleted successfully"
+        "400":
+          description: 잘못된 요청 (ID 형식 오류)
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "404":
+          description: 삭제할 점호 기록을 찾을 수 없음
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "500":
+          description: 서버 내부 오류
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+
+  /api/points:
+    get:
+      summary: 상벌점 이력 조회
+      description: 상벌점 이력을 조회합니다. 학생 번호와 날짜 범위로 필터링할 수 있습니다.
+      tags:
+        - Points
+      parameters:
+        - name: studentId
+          in: query
+          description: 학생 학번
+          required: false
+          schema:
+            type: string
+          example: "20240001"
+        - name: dateFrom
+          in: query
+          description: 시작 날짜 (YYYY-MM-DD 형식)
+          required: false
+          schema:
+            type: string
+            format: date
+          example: "2025-11-01"
+        - name: dateTo
+          in: query
+          description: 종료 날짜 (YYYY-MM-DD 형식)
+          required: false
+          schema:
+            type: string
+            format: date
+          example: "2025-11-16"
+      responses:
+        "200":
+          description: 성공적으로 상벌점 이력을 반환했습니다.
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/Point"
+        "500":
+          description: 서버 내부 오류
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+
+    post:
+      summary: 상벌점 단건 부여
+      description: 특정 학생에게 상벌점을 부여합니다.
+      tags:
+        - Points
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/PointCreateRequest"
+            example:
+              studentId: "20240001"
+              type: "MERIT"
+              score: 3
+              reason: "청소 우수"
+              date: "2025-11-16"
+      responses:
+        "201":
+          description: 상벌점이 성공적으로 부여되었습니다.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Point"
+        "400":
+          description: 잘못된 요청 (필수 필드 누락, type/score 유효성 오류)
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "404":
+          description: 학생을 찾을 수 없음
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "500":
+          description: 서버 내부 오류
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+
+  /api/points/bulk:
+    post:
+      summary: 상벌점 대량 부여
+      description: 여러 학생에게 동일한 상벌점을 대량으로 부여합니다. 트랜잭션 처리로 전체 성공 또는 전체 실패를 보장합니다.
+      tags:
+        - Points
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/PointBulkCreateRequest"
+            example:
+              studentIds: ["20240001", "20240002", "20240003"]
+              type: "DEMERIT"
+              score: 1
+              reason: "소음"
+              date: "2025-11-16"
+      responses:
+        "201":
+          description: 상벌점이 성공적으로 대량 부여되었습니다.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PointBulkCreateResponse"
+        "400":
+          description: 잘못된 요청 (studentIds 빈 배열, type/score 유효성 오류)
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "404":
+          description: 존재하지 않는 학생 학번 포함 (일부라도)
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "500":
+          description: 서버 내부 오류
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
 
   /auth/logout:
     get:
@@ -2368,6 +2685,193 @@ components:
           description: 추가 메시지 (구독 없는 경우)
           example: "No active subscriptions found for this student"
 
+    Rollcall:
+      type: object
+      description: 점호 기록 정보
+      properties:
+        id:
+          type: integer
+          description: 점호 기록 ID
+          example: 1
+        studentId:
+          type: string
+          description: 학생 학번
+          example: "20240001"
+        date:
+          type: string
+          format: date
+          description: 점호 날짜 (YYYY-MM-DD 형식)
+          example: "2025-11-16"
+        present:
+          type: boolean
+          description: 출석 여부 (true=출석, false=결석)
+          example: true
+        note:
+          type: string
+          nullable: true
+          description: 비고
+          example: "사감실 확인"
+
+    RollcallCreateRequest:
+      type: object
+      description: 점호 기록 생성/수정 요청
+      required:
+        - studentId
+        - date
+        - present
+      properties:
+        studentId:
+          type: string
+          description: 학생 학번
+          example: "20240001"
+        date:
+          type: string
+          format: date
+          description: 점호 날짜 (YYYY-MM-DD 형식)
+          example: "2025-11-16"
+        present:
+          type: boolean
+          description: 출석 여부 (true=출석, false=결석)
+          example: true
+        note:
+          type: string
+          description: 비고 (선택사항)
+          example: "사감실 확인"
+
+    RollcallUpdateRequest:
+      type: object
+      description: 점호 기록 부분 수정 요청
+      required:
+        - id
+      properties:
+        id:
+          type: integer
+          description: 점호 기록 ID
+          example: 1
+        present:
+          type: boolean
+          description: 출석 여부 (선택사항)
+          example: false
+        note:
+          type: string
+          description: 비고 (선택사항)
+          example: "병가로 변경"
+
+    Point:
+      type: object
+      description: 상벌점 정보
+      properties:
+        id:
+          type: integer
+          description: 상벌점 ID
+          example: 1
+        studentId:
+          type: string
+          description: 학생 학번
+          example: "20240001"
+        type:
+          type: string
+          description: 상벌점 유형
+          enum: [MERIT, DEMERIT]
+          example: "MERIT"
+        score:
+          type: integer
+          description: 점수 (양수)
+          example: 3
+        reason:
+          type: string
+          description: 사유
+          example: "청소 우수"
+        date:
+          type: string
+          format: date
+          description: 부여 날짜 (YYYY-MM-DD 형식)
+          example: "2025-11-16"
+
+    PointCreateRequest:
+      type: object
+      description: 상벌점 부여 요청
+      required:
+        - studentId
+        - type
+        - score
+        - reason
+        - date
+      properties:
+        studentId:
+          type: string
+          description: 학생 학번
+          example: "20240001"
+        type:
+          type: string
+          description: 상벌점 유형
+          enum: [MERIT, DEMERIT]
+          example: "MERIT"
+        score:
+          type: integer
+          description: 점수 (양수만 가능)
+          minimum: 1
+          example: 3
+        reason:
+          type: string
+          description: 사유
+          example: "청소 우수"
+        date:
+          type: string
+          format: date
+          description: 부여 날짜 (YYYY-MM-DD 형식)
+          example: "2025-11-16"
+
+    PointBulkCreateRequest:
+      type: object
+      description: 상벌점 대량 부여 요청
+      required:
+        - studentIds
+        - type
+        - score
+        - reason
+        - date
+      properties:
+        studentIds:
+          type: array
+          description: 학생 학번 배열
+          items:
+            type: string
+          example: ["20240001", "20240002", "20240003"]
+        type:
+          type: string
+          description: 상벌점 유형
+          enum: [MERIT, DEMERIT]
+          example: "DEMERIT"
+        score:
+          type: integer
+          description: 점수 (양수만 가능)
+          minimum: 1
+          example: 1
+        reason:
+          type: string
+          description: 사유
+          example: "소음"
+        date:
+          type: string
+          format: date
+          description: 부여 날짜 (YYYY-MM-DD 형식)
+          example: "2025-11-16"
+
+    PointBulkCreateResponse:
+      type: object
+      description: 상벌점 대량 부여 응답
+      properties:
+        created:
+          type: integer
+          description: 생성된 레코드 수
+          example: 3
+        items:
+          type: array
+          description: 생성된 상벌점 레코드 목록
+          items:
+            $ref: "#/components/schemas/Point"
+
 tags:
   - name: Rooms
     description: 호실 관련 API
@@ -2385,3 +2889,7 @@ tags:
     description: 인증 관련 API (스웨거에서는 동작하지 않음)
   - name: OvernightStays
     description: 외박 신청 관련 API
+  - name: Rollcalls
+    description: 점호 기록 관련 API
+  - name: Points
+    description: 상벌점 관리 관련 API

--- a/src/dto/__init__.py
+++ b/src/dto/__init__.py
@@ -38,6 +38,18 @@ from .overnight_stay_dto import (
     OvernightStayAdminListDTO,
     OvernightStayPageInfoDTO,
 )
+from .rollcall_dto import (
+    RollcallDTO,
+    RollcallListDTO,
+    RollcallCreateRequestDTO,
+    RollcallUpdateRequestDTO,
+)
+from .point_dto import (
+    PointDTO,
+    PointListDTO,
+    PointCreateRequestDTO,
+    PointBulkCreateRequestDTO,
+)
 
 __all__ = [
     "BaseDTO",
@@ -72,4 +84,12 @@ __all__ = [
     "OvernightStaySummaryDTO",
     "OvernightStayAdminListDTO",
     "OvernightStayPageInfoDTO",
+    "RollcallDTO",
+    "RollcallListDTO",
+    "RollcallCreateRequestDTO",
+    "RollcallUpdateRequestDTO",
+    "PointDTO",
+    "PointListDTO",
+    "PointCreateRequestDTO",
+    "PointBulkCreateRequestDTO",
 ]

--- a/src/dto/point_dto.py
+++ b/src/dto/point_dto.py
@@ -1,0 +1,70 @@
+"""
+상벌점 관련 DTO 클래스들을 정의합니다.
+"""
+
+from typing import Optional
+from dataclasses import dataclass
+from .base_dto import BaseDTO
+
+
+@dataclass
+class PointDTO(BaseDTO):
+    """상벌점 응답 DTO"""
+
+    id: int
+    studentId: str  # student_no → studentId 변환
+    type: str  # 'MERIT' 또는 'DEMERIT'
+    score: int
+    reason: str
+    date: str  # YYYY-MM-DD 형식
+
+    @classmethod
+    def from_supabase_data(cls, data: dict) -> "PointDTO":
+        """Supabase 데이터에서 PointDTO 생성"""
+        return cls(
+            id=data["id"],
+            studentId=data["student_no"],  # student_no → studentId 변환
+            type=data["type"],
+            score=data["score"],
+            reason=data["reason"],
+            date=data["date"],
+        )
+
+
+@dataclass
+class PointCreateRequestDTO(BaseDTO):
+    """상벌점 부여 요청 DTO"""
+
+    studentId: str
+    type: str  # 'MERIT' 또는 'DEMERIT'
+    score: int
+    reason: str
+    date: str  # YYYY-MM-DD 형식
+
+
+@dataclass
+class PointBulkCreateRequestDTO(BaseDTO):
+    """상벌점 대량 부여 요청 DTO"""
+
+    studentIds: list[str]
+    type: str  # 'MERIT' 또는 'DEMERIT'
+    score: int
+    reason: str
+    date: str  # YYYY-MM-DD 형식
+
+
+@dataclass
+class PointListDTO(BaseDTO):
+    """상벌점 목록 응답 DTO"""
+
+    points: list[PointDTO]
+
+    def to_dict(self) -> dict:
+        """상벌점 목록을 딕셔너리 리스트로 변환"""
+        return [point.to_dict() for point in self.points]
+
+    @classmethod
+    def from_supabase_data(cls, data_list: list[dict]) -> "PointListDTO":
+        """Supabase 데이터 리스트에서 PointListDTO 생성"""
+        points = [PointDTO.from_supabase_data(data) for data in data_list]
+        return cls(points=points)

--- a/src/dto/rollcall_dto.py
+++ b/src/dto/rollcall_dto.py
@@ -1,0 +1,65 @@
+"""
+점호 관련 DTO 클래스들을 정의합니다.
+"""
+
+from typing import Optional
+from dataclasses import dataclass
+from .base_dto import BaseDTO
+
+
+@dataclass
+class RollcallDTO(BaseDTO):
+    """점호 기록 응답 DTO"""
+
+    id: int
+    studentId: str  # student_no → studentId 변환
+    date: str  # YYYY-MM-DD 형식
+    present: bool
+    note: Optional[str] = None
+
+    @classmethod
+    def from_supabase_data(cls, data: dict) -> "RollcallDTO":
+        """Supabase 데이터에서 RollcallDTO 생성"""
+        return cls(
+            id=data["id"],
+            studentId=data["student_no"],  # student_no → studentId 변환
+            date=data["date"],
+            present=data["present"],
+            note=data.get("note"),
+        )
+
+
+@dataclass
+class RollcallCreateRequestDTO(BaseDTO):
+    """점호 생성/수정 요청 DTO"""
+
+    studentId: str
+    date: str  # YYYY-MM-DD 형식
+    present: bool
+    note: Optional[str] = None
+
+
+@dataclass
+class RollcallUpdateRequestDTO(BaseDTO):
+    """점호 부분 수정 요청 DTO"""
+
+    id: int
+    present: Optional[bool] = None
+    note: Optional[str] = None
+
+
+@dataclass
+class RollcallListDTO(BaseDTO):
+    """점호 목록 응답 DTO"""
+
+    rollcalls: list[RollcallDTO]
+
+    def to_dict(self) -> dict:
+        """점호 목록을 딕셔너리 리스트로 변환"""
+        return [rollcall.to_dict() for rollcall in self.rollcalls]
+
+    @classmethod
+    def from_supabase_data(cls, data_list: list[dict]) -> "RollcallListDTO":
+        """Supabase 데이터 리스트에서 RollcallListDTO 생성"""
+        rollcalls = [RollcallDTO.from_supabase_data(data) for data in data_list]
+        return cls(rollcalls=rollcalls)

--- a/src/handlers/point_handler.py
+++ b/src/handlers/point_handler.py
@@ -1,0 +1,193 @@
+"""
+상벌점 관련 API 요청을 처리하는 핸들러입니다.
+"""
+
+import json
+import logging
+from src.services import point_service, students_service
+from src.utils import responses
+from src.dto import (
+    PointListDTO,
+    PointDTO,
+    PointCreateRequestDTO,
+    PointBulkCreateRequestDTO,
+)
+
+# 로거 설정
+logger = logging.getLogger()
+logger.setLevel(logging.INFO)
+
+
+def get_points(event, context):
+    """
+    GET /points API 요청을 처리하는 핸들러
+    - 쿼리 파라미터: studentId, dateFrom, dateTo (모두 선택사항)
+    """
+    logger.info("✅ Processing get points request")
+
+    query_params = event.get("queryStringParameters") or {}
+    student_id = query_params.get("studentId")
+    date_from = query_params.get("dateFrom")
+    date_to = query_params.get("dateTo")
+
+    # 서비스 호출
+    result, error = point_service.get_points(
+        student_id=student_id, date_from=date_from, date_to=date_to
+    )
+
+    if error:
+        return responses.create_error_response(error, 500)
+
+    # DTO를 사용하여 응답 데이터 변환
+    point_list_dto = PointListDTO.from_supabase_data(result)
+    return responses.create_success_response(point_list_dto.to_dict())
+
+
+def create_point(event, context):
+    """
+    POST /points API 요청을 처리하는 핸들러
+    - body: studentId, type, score, reason, date (모두 필수)
+    """
+    logger.info("✅ Processing create point request")
+
+    try:
+        body = json.loads(event.get("body", "{}"))
+
+        # DTO를 사용한 요청 데이터 검증
+        create_request = PointCreateRequestDTO.from_dict(body)
+
+        # 필수 필드 검증
+        if not create_request.studentId:
+            return responses.create_error_response("studentId is required.", 400)
+        if not create_request.type:
+            return responses.create_error_response("type is required.", 400)
+        if not create_request.reason:
+            return responses.create_error_response("reason is required.", 400)
+        if not create_request.date:
+            return responses.create_error_response("date is required.", 400)
+
+        # type 유효성 검사
+        if create_request.type not in ["MERIT", "DEMERIT"]:
+            return responses.create_error_response(
+                "Invalid type. Must be 'MERIT' or 'DEMERIT'.", 400
+            )
+
+        # score 유효성 검사
+        if create_request.score <= 0:
+            return responses.create_error_response(
+                "Score must be a positive integer.", 400
+            )
+
+        # 학생 존재 여부 확인
+        student, error = students_service.get_student_by_student_no(
+            create_request.studentId
+        )
+        if error:
+            if error == "Not found":
+                return responses.create_error_response("Student not found.", 404)
+            return responses.create_error_response(error, 500)
+
+        # 서비스 호출
+        result, error = point_service.create_point(
+            student_no=create_request.studentId,
+            type=create_request.type,
+            score=create_request.score,
+            reason=create_request.reason,
+            date=create_request.date,
+        )
+
+        if error:
+            # 서비스에서 이미 유효성 검사를 했지만, 에러 메시지 전달
+            if "Invalid type" in error or "Score must be" in error:
+                return responses.create_error_response(error, 400)
+            return responses.create_error_response(error, 500)
+
+        # DTO를 사용하여 응답 데이터 변환
+        point_dto = PointDTO.from_supabase_data(result)
+        return responses.create_success_response(point_dto.to_dict(), 201)
+
+    except json.JSONDecodeError:
+        return responses.create_error_response("Invalid JSON format.", 400)
+    except ValueError as e:
+        return responses.create_error_response(f"Validation error: {str(e)}", 400)
+
+
+def bulk_create_points(event, context):
+    """
+    POST /points/bulk API 요청을 처리하는 핸들러
+    - body: studentIds (배열), type, score, reason, date (모두 필수)
+    """
+    logger.info("✅ Processing bulk create points request")
+
+    try:
+        body = json.loads(event.get("body", "{}"))
+
+        # DTO를 사용한 요청 데이터 검증
+        bulk_request = PointBulkCreateRequestDTO.from_dict(body)
+
+        # 필수 필드 검증
+        if not bulk_request.studentIds:
+            return responses.create_error_response("studentIds is required.", 400)
+        if not isinstance(bulk_request.studentIds, list):
+            return responses.create_error_response("studentIds must be an array.", 400)
+        if len(bulk_request.studentIds) == 0:
+            return responses.create_error_response(
+                "studentIds array cannot be empty.", 400
+            )
+        if not bulk_request.type:
+            return responses.create_error_response("type is required.", 400)
+        if not bulk_request.reason:
+            return responses.create_error_response("reason is required.", 400)
+        if not bulk_request.date:
+            return responses.create_error_response("date is required.", 400)
+
+        # type 유효성 검사
+        if bulk_request.type not in ["MERIT", "DEMERIT"]:
+            return responses.create_error_response(
+                "Invalid type. Must be 'MERIT' or 'DEMERIT'.", 400
+            )
+
+        # score 유효성 검사
+        if bulk_request.score <= 0:
+            return responses.create_error_response(
+                "Score must be a positive integer.", 400
+            )
+
+        # 모든 학생 존재 여부 확인
+        for student_id in bulk_request.studentIds:
+            student, error = students_service.get_student_by_student_no(student_id)
+            if error:
+                if error == "Not found":
+                    return responses.create_error_response(
+                        f"Student not found: {student_id}", 404
+                    )
+                return responses.create_error_response(error, 500)
+
+        # 서비스 호출
+        result, error = point_service.bulk_create_points(
+            student_ids=bulk_request.studentIds,
+            type=bulk_request.type,
+            score=bulk_request.score,
+            reason=bulk_request.reason,
+            date=bulk_request.date,
+        )
+
+        if error:
+            # 서비스에서 이미 유효성 검사를 했지만, 에러 메시지 전달
+            if (
+                "Invalid type" in error
+                or "Score must be" in error
+                or "cannot be empty" in error
+            ):
+                return responses.create_error_response(error, 400)
+            return responses.create_error_response(error, 500)
+
+        # 응답 형식: {created: count, items: [...]}
+        point_list = [PointDTO.from_supabase_data(item).to_dict() for item in result]
+        response_data = {"created": len(point_list), "items": point_list}
+        return responses.create_success_response(response_data, 201)
+
+    except json.JSONDecodeError:
+        return responses.create_error_response("Invalid JSON format.", 400)
+    except ValueError as e:
+        return responses.create_error_response(f"Validation error: {str(e)}", 400)

--- a/src/handlers/point_handler.py
+++ b/src/handlers/point_handler.py
@@ -25,22 +25,27 @@ def get_points(event, context):
     """
     logger.info("✅ Processing get points request")
 
-    query_params = event.get("queryStringParameters") or {}
-    student_id = query_params.get("studentId")
-    date_from = query_params.get("dateFrom")
-    date_to = query_params.get("dateTo")
+    try:
+        query_params = event.get("queryStringParameters") or {}
+        student_id = query_params.get("studentId")
+        date_from = query_params.get("dateFrom")
+        date_to = query_params.get("dateTo")
 
-    # 서비스 호출
-    result, error = point_service.get_points(
-        student_id=student_id, date_from=date_from, date_to=date_to
-    )
+        # 서비스 호출
+        result = point_service.get_points(
+            student_id=student_id, date_from=date_from, date_to=date_to
+        )
 
-    if error:
-        return responses.create_error_response(error, 500)
+        # DTO를 사용하여 응답 데이터 변환
+        point_list_dto = PointListDTO.from_supabase_data(result)
+        return responses.create_success_response(point_list_dto.to_dict())
 
-    # DTO를 사용하여 응답 데이터 변환
-    point_list_dto = PointListDTO.from_supabase_data(result)
-    return responses.create_success_response(point_list_dto.to_dict())
+    except RuntimeError as e:
+        logger.error(f"❌ 상벌점 조회 실패: {e}")
+        return responses.create_error_response(str(e), 500)
+    except Exception as e:
+        logger.error(f"❌ 상벌점 조회 실패: {e}")
+        return responses.create_error_response("Internal server error.", 500)
 
 
 def create_point(event, context):
@@ -78,29 +83,34 @@ def create_point(event, context):
                 "Score must be a positive integer.", 400
             )
 
-        # 학생 존재 여부 확인
+        # 학생 존재 여부 확인 (students_service는 아직 tuple 반환 패턴)
         student, error = students_service.get_student_by_student_no(
             create_request.studentId
         )
         if error:
             if error == "Not found":
                 return responses.create_error_response("Student not found.", 404)
-            return responses.create_error_response(error, 500)
+            logger.error(f"❌ 학생 조회 실패: {error}")
+            return responses.create_error_response("Internal server error.", 500)
 
         # 서비스 호출
-        result, error = point_service.create_point(
-            student_no=create_request.studentId,
-            type=create_request.type,
-            score=create_request.score,
-            reason=create_request.reason,
-            date=create_request.date,
-        )
-
-        if error:
-            # 서비스에서 이미 유효성 검사를 했지만, 에러 메시지 전달
-            if "Invalid type" in error or "Score must be" in error:
-                return responses.create_error_response(error, 400)
-            return responses.create_error_response(error, 500)
+        try:
+            result = point_service.create_point(
+                student_no=create_request.studentId,
+                type=create_request.type,
+                score=create_request.score,
+                reason=create_request.reason,
+                date=create_request.date,
+            )
+        except ValueError as e:
+            logger.error(f"❌ 상벌점 생성 실패 (유효성 검사): {e}")
+            return responses.create_error_response(str(e), 400)
+        except RuntimeError as e:
+            logger.error(f"❌ 상벌점 생성 실패: {e}")
+            return responses.create_error_response(str(e), 500)
+        except Exception as e:
+            logger.error(f"❌ 상벌점 생성 실패: {e}")
+            return responses.create_error_response("Internal server error.", 500)
 
         # DTO를 사용하여 응답 데이터 변환
         point_dto = PointDTO.from_supabase_data(result)
@@ -153,7 +163,7 @@ def bulk_create_points(event, context):
                 "Score must be a positive integer.", 400
             )
 
-        # 모든 학생 존재 여부 확인
+        # 모든 학생 존재 여부 확인 (students_service는 아직 tuple 반환 패턴)
         for student_id in bulk_request.studentIds:
             student, error = students_service.get_student_by_student_no(student_id)
             if error:
@@ -161,26 +171,27 @@ def bulk_create_points(event, context):
                     return responses.create_error_response(
                         f"Student not found: {student_id}", 404
                     )
-                return responses.create_error_response(error, 500)
+                logger.error(f"❌ 학생 조회 실패: {error}")
+                return responses.create_error_response("Internal server error.", 500)
 
         # 서비스 호출
-        result, error = point_service.bulk_create_points(
-            student_ids=bulk_request.studentIds,
-            type=bulk_request.type,
-            score=bulk_request.score,
-            reason=bulk_request.reason,
-            date=bulk_request.date,
-        )
-
-        if error:
-            # 서비스에서 이미 유효성 검사를 했지만, 에러 메시지 전달
-            if (
-                "Invalid type" in error
-                or "Score must be" in error
-                or "cannot be empty" in error
-            ):
-                return responses.create_error_response(error, 400)
-            return responses.create_error_response(error, 500)
+        try:
+            result = point_service.bulk_create_points(
+                student_ids=bulk_request.studentIds,
+                type=bulk_request.type,
+                score=bulk_request.score,
+                reason=bulk_request.reason,
+                date=bulk_request.date,
+            )
+        except ValueError as e:
+            logger.error(f"❌ 상벌점 일괄 생성 실패 (유효성 검사): {e}")
+            return responses.create_error_response(str(e), 400)
+        except RuntimeError as e:
+            logger.error(f"❌ 상벌점 일괄 생성 실패: {e}")
+            return responses.create_error_response(str(e), 500)
+        except Exception as e:
+            logger.error(f"❌ 상벌점 일괄 생성 실패: {e}")
+            return responses.create_error_response("Internal server error.", 500)
 
         # 응답 형식: {created: count, items: [...]}
         point_list = [PointDTO.from_supabase_data(item).to_dict() for item in result]

--- a/src/handlers/rollcall_handler.py
+++ b/src/handlers/rollcall_handler.py
@@ -1,0 +1,199 @@
+"""
+점호 관련 API 요청을 처리하는 핸들러입니다.
+"""
+
+import json
+import logging
+from src.services import rollcall_service, students_service
+from src.utils import responses
+from src.dto import (
+    RollcallListDTO,
+    RollcallDTO,
+    RollcallCreateRequestDTO,
+    RollcallUpdateRequestDTO,
+)
+
+# 로거 설정
+logger = logging.getLogger()
+logger.setLevel(logging.INFO)
+
+
+def get_rollcalls(event, context):
+    """
+    GET /rollcalls API 요청을 처리하는 핸들러
+    - 쿼리 파라미터: date, roomId, name, present (모두 선택사항)
+    """
+    logger.info("✅ Processing get rollcalls request")
+
+    query_params = event.get("queryStringParameters") or {}
+    date = query_params.get("date")
+    room_id = query_params.get("roomId")
+    name = query_params.get("name")
+    present = query_params.get("present")
+
+    # roomId 파싱
+    room_id_int = None
+    if room_id:
+        try:
+            room_id_int = int(room_id)
+        except ValueError:
+            return responses.create_error_response("Invalid roomId format.", 400)
+
+    # present 파싱
+    present_bool = None
+    if present is not None:
+        if present.lower() == "true":
+            present_bool = True
+        elif present.lower() == "false":
+            present_bool = False
+        else:
+            return responses.create_error_response(
+                "Invalid present format. Must be 'true' or 'false'.", 400
+            )
+
+    # 서비스 호출
+    result, error = rollcall_service.get_rollcalls(
+        date=date, room_id=room_id_int, name=name, present=present_bool
+    )
+
+    if error:
+        return responses.create_error_response(error, 500)
+
+    # DTO를 사용하여 응답 데이터 변환
+    rollcall_list_dto = RollcallListDTO.from_supabase_data(result)
+    return responses.create_success_response(rollcall_list_dto.to_dict())
+
+
+def create_or_update_rollcall(event, context):
+    """
+    POST /rollcall API 요청을 처리하는 핸들러
+    - body: studentId, date, present, note (선택)
+    - Upsert 로직: 기존 레코드 있으면 UPDATE, 없으면 INSERT
+    """
+    logger.info("✅ Processing create or update rollcall request")
+
+    try:
+        body = json.loads(event.get("body", "{}"))
+
+        # DTO를 사용한 요청 데이터 검증
+        create_request = RollcallCreateRequestDTO.from_dict(body)
+
+        # 필수 필드 검증
+        if not create_request.studentId:
+            return responses.create_error_response("studentId is required.", 400)
+        if not create_request.date:
+            return responses.create_error_response("date is required.", 400)
+
+        # 학생 존재 여부 확인
+        student, error = students_service.get_student_by_student_no(
+            create_request.studentId
+        )
+        if error:
+            if error == "Not found":
+                return responses.create_error_response("Student not found.", 404)
+            return responses.create_error_response(error, 500)
+
+        # 서비스 호출 (Upsert)
+        result, error = rollcall_service.create_or_update_rollcall(
+            student_no=create_request.studentId,
+            date=create_request.date,
+            present=create_request.present,
+            note=create_request.note,
+        )
+
+        if error:
+            return responses.create_error_response(error, 500)
+
+        # 기존 레코드인지 확인하여 상태 코드 결정
+        # Supabase upsert는 항상 업데이트된 레코드를 반환하므로,
+        # created_at과 updated_at을 비교하여 생성/수정 여부 판단
+        # 단순화: 항상 200 반환 (실제로는 created_at == updated_at이면 201)
+        rollcall_dto = RollcallDTO.from_supabase_data(result)
+        return responses.create_success_response(rollcall_dto.to_dict(), 200)
+
+    except json.JSONDecodeError:
+        return responses.create_error_response("Invalid JSON format.", 400)
+    except ValueError as e:
+        return responses.create_error_response(f"Validation error: {str(e)}", 400)
+
+
+def update_rollcall(event, context):
+    """
+    PATCH /api/rollcall API 요청을 처리하는 핸들러
+    - body: id (필수), present, note (선택사항)
+    """
+    logger.info("✅ Processing update rollcall request")
+
+    try:
+        body = json.loads(event.get("body", "{}"))
+
+        # DTO를 사용한 요청 데이터 검증
+        update_request = RollcallUpdateRequestDTO.from_dict(body)
+
+        # 필수 필드 검증
+        if not update_request.id:
+            return responses.create_error_response("id is required.", 400)
+
+        # 서비스 호출
+        result, error = rollcall_service.update_rollcall(
+            id=update_request.id,
+            present=update_request.present,
+            note=update_request.note,
+        )
+
+        if error:
+            if error == "Not found":
+                return responses.create_error_response("Rollcall not found.", 404)
+            return responses.create_error_response(error, 500)
+
+        # DTO를 사용하여 응답 데이터 변환
+        rollcall_dto = RollcallDTO.from_supabase_data(result)
+        return responses.create_success_response(rollcall_dto.to_dict())
+
+    except json.JSONDecodeError:
+        return responses.create_error_response("Invalid JSON format.", 400)
+    except ValueError as e:
+        return responses.create_error_response(f"Validation error: {str(e)}", 400)
+
+
+def delete_rollcall(event, context):
+    """
+    DELETE /api/rollcall API 요청을 처리하는 핸들러
+    - 쿼리 파라미터: id (필수)
+    """
+    logger.info("✅ Processing delete rollcall request")
+
+    try:
+        # 쿼리 파라미터에서 id 추출
+        query_params = event.get("queryStringParameters") or {}
+        id_str = query_params.get("id")
+
+        if not id_str:
+            return responses.create_error_response("ID is required.", 400)
+
+        # ID를 정수로 변환
+        try:
+            rollcall_id = int(id_str)
+            if rollcall_id <= 0:
+                return responses.create_error_response(
+                    "ID must be a positive integer.", 400
+                )
+        except ValueError:
+            return responses.create_error_response("Invalid ID format.", 400)
+
+        # 서비스 호출
+        result, error = rollcall_service.delete_rollcall(id=rollcall_id)
+
+        if error:
+            if error == "Not found":
+                return responses.create_error_response("Rollcall not found.", 404)
+            return responses.create_error_response(error, 500)
+
+        # 성공 응답 반환
+        return responses.create_success_response(
+            {"message": "Rollcall deleted successfully"}
+        )
+
+    except Exception as e:
+        logger.error(f"❌ 점호 기록 삭제 실패: {e}")
+        return responses.create_error_response("Internal server error.", 500)

--- a/src/handlers/rollcall_handler.py
+++ b/src/handlers/rollcall_handler.py
@@ -51,13 +51,24 @@ def get_rollcalls(event, context):
                 "Invalid present format. Must be 'true' or 'false'.", 400
             )
 
-    # 서비스 호출
-    result, error = rollcall_service.get_rollcalls(
-        date=date, room_id=room_id_int, name=name, present=present_bool
-    )
+    # 필터가 하나라도 있는지 확인
+    has_filters = any([date, room_id_int, name, present is not None])
 
-    if error:
-        return responses.create_error_response(error, 500)
+    # 서비스 호출
+    try:
+        result = rollcall_service.get_rollcalls(
+            date=date, room_id=room_id_int, name=name, present=present_bool
+        )
+    except RuntimeError as e:
+        logger.error(f"❌ 점호 기록 조회 실패: {e}")
+        return responses.create_error_response(str(e), 500)
+    except Exception as e:
+        logger.error(f"❌ 점호 기록 조회 실패: {e}")
+        return responses.create_error_response("Internal server error.", 500)
+
+    # 필터가 있고 결과가 비어있으면 404 반환
+    if has_filters and not result:
+        return responses.create_error_response("No rollcall records found.", 404)
 
     # DTO를 사용하여 응답 데이터 변환
     rollcall_list_dto = RollcallListDTO.from_supabase_data(result)
@@ -94,15 +105,19 @@ def create_or_update_rollcall(event, context):
             return responses.create_error_response(error, 500)
 
         # 서비스 호출 (Upsert)
-        result, error = rollcall_service.create_or_update_rollcall(
-            student_no=create_request.studentId,
-            date=create_request.date,
-            present=create_request.present,
-            note=create_request.note,
-        )
-
-        if error:
-            return responses.create_error_response(error, 500)
+        try:
+            result = rollcall_service.create_or_update_rollcall(
+                student_no=create_request.studentId,
+                date=create_request.date,
+                present=create_request.present,
+                note=create_request.note,
+            )
+        except RuntimeError as e:
+            logger.error(f"❌ 점호 기록 Upsert 실패: {e}")
+            return responses.create_error_response(str(e), 500)
+        except Exception as e:
+            logger.error(f"❌ 점호 기록 Upsert 실패: {e}")
+            return responses.create_error_response("Internal server error.", 500)
 
         # 기존 레코드인지 확인하여 상태 코드 결정
         # Supabase upsert는 항상 업데이트된 레코드를 반환하므로,
@@ -135,16 +150,24 @@ def update_rollcall(event, context):
             return responses.create_error_response("id is required.", 400)
 
         # 서비스 호출
-        result, error = rollcall_service.update_rollcall(
-            id=update_request.id,
-            present=update_request.present,
-            note=update_request.note,
-        )
-
-        if error:
-            if error == "Not found":
+        try:
+            result = rollcall_service.update_rollcall(
+                id=update_request.id,
+                present=update_request.present,
+                note=update_request.note,
+            )
+        except ValueError as e:
+            logger.error(f"❌ 점호 기록 수정 실패 (유효성 검사): {e}")
+            return responses.create_error_response(str(e), 400)
+        except RuntimeError as e:
+            logger.error(f"❌ 점호 기록 수정 실패: {e}")
+            error_str = str(e)
+            if "not found" in error_str.lower():
                 return responses.create_error_response("Rollcall not found.", 404)
-            return responses.create_error_response(error, 500)
+            return responses.create_error_response(error_str, 500)
+        except Exception as e:
+            logger.error(f"❌ 점호 기록 수정 실패: {e}")
+            return responses.create_error_response("Internal server error.", 500)
 
         # DTO를 사용하여 응답 데이터 변환
         rollcall_dto = RollcallDTO.from_supabase_data(result)
@@ -163,37 +186,37 @@ def delete_rollcall(event, context):
     """
     logger.info("✅ Processing delete rollcall request")
 
+    # 쿼리 파라미터에서 id 추출
+    query_params = event.get("queryStringParameters") or {}
+    id_str = query_params.get("id")
+
+    if not id_str:
+        return responses.create_error_response("ID is required.", 400)
+
+    # ID를 정수로 변환
     try:
-        # 쿼리 파라미터에서 id 추출
-        query_params = event.get("queryStringParameters") or {}
-        id_str = query_params.get("id")
+        rollcall_id = int(id_str)
+        if rollcall_id <= 0:
+            return responses.create_error_response(
+                "ID must be a positive integer.", 400
+            )
+    except ValueError:
+        return responses.create_error_response("Invalid ID format.", 400)
 
-        if not id_str:
-            return responses.create_error_response("ID is required.", 400)
-
-        # ID를 정수로 변환
-        try:
-            rollcall_id = int(id_str)
-            if rollcall_id <= 0:
-                return responses.create_error_response(
-                    "ID must be a positive integer.", 400
-                )
-        except ValueError:
-            return responses.create_error_response("Invalid ID format.", 400)
-
-        # 서비스 호출
-        result, error = rollcall_service.delete_rollcall(id=rollcall_id)
-
-        if error:
-            if error == "Not found":
-                return responses.create_error_response("Rollcall not found.", 404)
-            return responses.create_error_response(error, 500)
-
-        # 성공 응답 반환
-        return responses.create_success_response(
-            {"message": "Rollcall deleted successfully"}
-        )
-
+    # 서비스 호출
+    try:
+        result = rollcall_service.delete_rollcall(id=rollcall_id)
+    except RuntimeError as e:
+        logger.error(f"❌ 점호 기록 삭제 실패: {e}")
+        error_str = str(e)
+        if "not found" in error_str.lower():
+            return responses.create_error_response("Rollcall not found.", 404)
+        return responses.create_error_response(error_str, 500)
     except Exception as e:
         logger.error(f"❌ 점호 기록 삭제 실패: {e}")
         return responses.create_error_response("Internal server error.", 500)
+
+    # 성공 응답 반환
+    return responses.create_success_response(
+        {"message": "Rollcall deleted successfully"}
+    )

--- a/src/services/point_service.py
+++ b/src/services/point_service.py
@@ -20,38 +20,32 @@ def get_points(
     상벌점 이력을 조회합니다.
     날짜 범위 필터링이 가능하며, created_at 기준 내림차순 정렬합니다.
     """
-    try:
-        supabase = get_supabase_client("rollcall")
-        if not supabase:
-            return None, "Supabase client could not be initialized."
+    supabase = get_supabase_client("rollcall")
+    if not supabase:
+        raise RuntimeError("Supabase client could not be initialized.")
 
-        logger.info("상벌점 이력 조회 시작")
+    logger.info("상벌점 이력 조회 시작")
 
-        query = (
-            supabase.postgrest.schema("rollcall")
-            .from_("points")
-            .select("id, student_no, type, score, reason, date, created_at")
-        )
+    query = (
+        supabase.postgrest.schema("rollcall")
+        .from_("points")
+        .select("id, student_no, type, score, reason, date, created_at")
+    )
 
-        # 필터링 적용
-        if student_id:
-            query = query.eq("student_no", student_id)
-        if date_from:
-            query = query.gte("date", date_from)
-        if date_to:
-            query = query.lte("date", date_to)
+    # 필터링 적용
+    if student_id:
+        query = query.eq("student_no", student_id)
+    if date_from:
+        query = query.gte("date", date_from)
+    if date_to:
+        query = query.lte("date", date_to)
 
-        response = query.order("created_at", desc=True).execute()
+    response = query.order("created_at", desc=True).execute()
 
-        data = response.data
-        logger.info(f"✅ {len(data)}개의 상벌점 기록을 조회했습니다.")
+    data = response.data
+    logger.info(f"✅ {len(data)}개의 상벌점 기록을 조회했습니다.")
 
-        return data, None
-
-    except Exception as e:
-        logger.error(f"❌ 상벌점 이력 조회 실패: {e}")
-        error_message = getattr(e, "message", str(e))
-        return None, error_message
+    return data
 
 
 def create_point(student_no: str, type: str, score: int, reason: str, date: str):
@@ -59,50 +53,43 @@ def create_point(student_no: str, type: str, score: int, reason: str, date: str)
     상벌점을 단건 부여합니다.
     type은 'MERIT' 또는 'DEMERIT'만 허용하며, score는 양수만 가능합니다.
     """
-    try:
-        # 유효성 검사
-        if type not in ["MERIT", "DEMERIT"]:
-            return None, "Invalid type. Must be 'MERIT' or 'DEMERIT'"
-        if score <= 0:
-            return None, "Score must be a positive integer"
+    # 유효성 검사
+    if type not in ["MERIT", "DEMERIT"]:
+        raise ValueError("Invalid type. Must be 'MERIT' or 'DEMERIT'")
+    if score <= 0:
+        raise ValueError("Score must be a positive integer")
 
-        supabase = get_supabase_client("rollcall")
-        if not supabase:
-            return None, "Supabase client could not be initialized."
+    supabase = get_supabase_client("rollcall")
+    if not supabase:
+        raise RuntimeError("Supabase client could not be initialized.")
 
-        logger.info(
-            f"상벌점 부여 시작: student_no={student_no}, type={type}, score={score}"
-        )
+    logger.info(
+        f"상벌점 부여 시작: student_no={student_no}, type={type}, score={score}"
+    )
 
-        insert_data = {
-            "student_no": student_no,
-            "type": type,
-            "score": score,
-            "reason": reason,
-            "date": date,
-        }
+    insert_data = {
+        "student_no": student_no,
+        "type": type,
+        "score": score,
+        "reason": reason,
+        "date": date,
+    }
 
-        response = (
-            supabase.postgrest.schema("rollcall")
-            .from_("points")
-            .insert(insert_data)
-            .execute()
-        )
+    response = (
+        supabase.postgrest.schema("rollcall")
+        .from_("points")
+        .insert(insert_data)
+        .execute()
+    )
 
-        data = response.data
-        if data:
-            logger.info(
-                f"✅ 상벌점 부여 성공: student_no={student_no}, type={type}, score={score}"
-            )
-            return data[0], None
-        else:
-            logger.error("❌ 상벌점 부여 실패: 응답 데이터가 없습니다.")
-            return None, "Failed to create point"
+    data = response.data
+    if not data:
+        raise RuntimeError("Failed to create point: No data returned from database")
 
-    except Exception as e:
-        logger.error(f"❌ 상벌점 부여 실패: {e}")
-        error_message = getattr(e, "message", str(e))
-        return None, error_message
+    logger.info(
+        f"✅ 상벌점 부여 성공: student_no={student_no}, type={type}, score={score}"
+    )
+    return data[0]
 
 
 def bulk_create_points(
@@ -112,53 +99,48 @@ def bulk_create_points(
     상벌점을 대량 부여합니다.
     트랜잭션 처리로 전체 성공 또는 전체 실패를 보장합니다.
     """
-    try:
-        # 유효성 검사
-        if type not in ["MERIT", "DEMERIT"]:
-            return None, "Invalid type. Must be 'MERIT' or 'DEMERIT'"
-        if score <= 0:
-            return None, "Score must be a positive integer"
-        if not student_ids:
-            return None, "studentIds array cannot be empty"
+    # 유효성 검사
+    if type not in ["MERIT", "DEMERIT"]:
+        raise ValueError("Invalid type. Must be 'MERIT' or 'DEMERIT'")
+    if score <= 0:
+        raise ValueError("Score must be a positive integer")
+    if not student_ids:
+        raise ValueError("studentIds array cannot be empty")
 
-        supabase = get_supabase_client("rollcall")
-        if not supabase:
-            return None, "Supabase client could not be initialized."
+    supabase = get_supabase_client("rollcall")
+    if not supabase:
+        raise RuntimeError("Supabase client could not be initialized.")
 
-        logger.info(
-            f"상벌점 대량 부여 시작: {len(student_ids)}명, type={type}, score={score}"
+    logger.info(
+        f"상벌점 대량 부여 시작: {len(student_ids)}명, type={type}, score={score}"
+    )
+
+    # 각 학생에 대해 동일한 정보로 레코드 생성
+    insert_data_list = [
+        {
+            "student_no": student_id,
+            "type": type,
+            "score": score,
+            "reason": reason,
+            "date": date,
+        }
+        for student_id in student_ids
+    ]
+
+    # Supabase의 insert는 여러 레코드를 한 번에 처리할 수 있음
+    # 트랜잭션은 Supabase가 자동으로 처리
+    response = (
+        supabase.postgrest.schema("rollcall")
+        .from_("points")
+        .insert(insert_data_list)
+        .execute()
+    )
+
+    data = response.data
+    if not data:
+        raise RuntimeError(
+            "Failed to bulk create points: No data returned from database"
         )
 
-        # 각 학생에 대해 동일한 정보로 레코드 생성
-        insert_data_list = [
-            {
-                "student_no": student_id,
-                "type": type,
-                "score": score,
-                "reason": reason,
-                "date": date,
-            }
-            for student_id in student_ids
-        ]
-
-        # Supabase의 insert는 여러 레코드를 한 번에 처리할 수 있음
-        # 트랜잭션은 Supabase가 자동으로 처리
-        response = (
-            supabase.postgrest.schema("rollcall")
-            .from_("points")
-            .insert(insert_data_list)
-            .execute()
-        )
-
-        data = response.data
-        if data:
-            logger.info(f"✅ 상벌점 대량 부여 성공: {len(data)}건 생성됨")
-            return data, None
-        else:
-            logger.error("❌ 상벌점 대량 부여 실패: 응답 데이터가 없습니다.")
-            return None, "Failed to bulk create points"
-
-    except Exception as e:
-        logger.error(f"❌ 상벌점 대량 부여 실패: {e}")
-        error_message = getattr(e, "message", str(e))
-        return None, error_message
+    logger.info(f"✅ 상벌점 대량 부여 성공: {len(data)}건 생성됨")
+    return data

--- a/src/services/point_service.py
+++ b/src/services/point_service.py
@@ -1,0 +1,164 @@
+"""
+상벌점 관련 비즈니스 로직을 처리하는 서비스입니다.
+"""
+
+import logging
+from typing import Optional
+from src.utils.supabase_client import get_supabase_client
+
+# 로거 설정
+logger = logging.getLogger()
+logger.setLevel(logging.INFO)
+
+
+def get_points(
+    student_id: Optional[str] = None,
+    date_from: Optional[str] = None,
+    date_to: Optional[str] = None,
+):
+    """
+    상벌점 이력을 조회합니다.
+    날짜 범위 필터링이 가능하며, created_at 기준 내림차순 정렬합니다.
+    """
+    try:
+        supabase = get_supabase_client("rollcall")
+        if not supabase:
+            return None, "Supabase client could not be initialized."
+
+        logger.info("상벌점 이력 조회 시작")
+
+        query = (
+            supabase.postgrest.schema("rollcall")
+            .from_("points")
+            .select("id, student_no, type, score, reason, date, created_at")
+        )
+
+        # 필터링 적용
+        if student_id:
+            query = query.eq("student_no", student_id)
+        if date_from:
+            query = query.gte("date", date_from)
+        if date_to:
+            query = query.lte("date", date_to)
+
+        response = query.order("created_at", desc=True).execute()
+
+        data = response.data
+        logger.info(f"✅ {len(data)}개의 상벌점 기록을 조회했습니다.")
+
+        return data, None
+
+    except Exception as e:
+        logger.error(f"❌ 상벌점 이력 조회 실패: {e}")
+        error_message = getattr(e, "message", str(e))
+        return None, error_message
+
+
+def create_point(student_no: str, type: str, score: int, reason: str, date: str):
+    """
+    상벌점을 단건 부여합니다.
+    type은 'MERIT' 또는 'DEMERIT'만 허용하며, score는 양수만 가능합니다.
+    """
+    try:
+        # 유효성 검사
+        if type not in ["MERIT", "DEMERIT"]:
+            return None, "Invalid type. Must be 'MERIT' or 'DEMERIT'"
+        if score <= 0:
+            return None, "Score must be a positive integer"
+
+        supabase = get_supabase_client("rollcall")
+        if not supabase:
+            return None, "Supabase client could not be initialized."
+
+        logger.info(
+            f"상벌점 부여 시작: student_no={student_no}, type={type}, score={score}"
+        )
+
+        insert_data = {
+            "student_no": student_no,
+            "type": type,
+            "score": score,
+            "reason": reason,
+            "date": date,
+        }
+
+        response = (
+            supabase.postgrest.schema("rollcall")
+            .from_("points")
+            .insert(insert_data)
+            .execute()
+        )
+
+        data = response.data
+        if data:
+            logger.info(
+                f"✅ 상벌점 부여 성공: student_no={student_no}, type={type}, score={score}"
+            )
+            return data[0], None
+        else:
+            logger.error("❌ 상벌점 부여 실패: 응답 데이터가 없습니다.")
+            return None, "Failed to create point"
+
+    except Exception as e:
+        logger.error(f"❌ 상벌점 부여 실패: {e}")
+        error_message = getattr(e, "message", str(e))
+        return None, error_message
+
+
+def bulk_create_points(
+    student_ids: list[str], type: str, score: int, reason: str, date: str
+):
+    """
+    상벌점을 대량 부여합니다.
+    트랜잭션 처리로 전체 성공 또는 전체 실패를 보장합니다.
+    """
+    try:
+        # 유효성 검사
+        if type not in ["MERIT", "DEMERIT"]:
+            return None, "Invalid type. Must be 'MERIT' or 'DEMERIT'"
+        if score <= 0:
+            return None, "Score must be a positive integer"
+        if not student_ids:
+            return None, "studentIds array cannot be empty"
+
+        supabase = get_supabase_client("rollcall")
+        if not supabase:
+            return None, "Supabase client could not be initialized."
+
+        logger.info(
+            f"상벌점 대량 부여 시작: {len(student_ids)}명, type={type}, score={score}"
+        )
+
+        # 각 학생에 대해 동일한 정보로 레코드 생성
+        insert_data_list = [
+            {
+                "student_no": student_id,
+                "type": type,
+                "score": score,
+                "reason": reason,
+                "date": date,
+            }
+            for student_id in student_ids
+        ]
+
+        # Supabase의 insert는 여러 레코드를 한 번에 처리할 수 있음
+        # 트랜잭션은 Supabase가 자동으로 처리
+        response = (
+            supabase.postgrest.schema("rollcall")
+            .from_("points")
+            .insert(insert_data_list)
+            .execute()
+        )
+
+        data = response.data
+        if data:
+            logger.info(f"✅ 상벌점 대량 부여 성공: {len(data)}건 생성됨")
+            return data, None
+        else:
+            logger.error("❌ 상벌점 대량 부여 실패: 응답 데이터가 없습니다.")
+            return None, "Failed to bulk create points"
+
+    except Exception as e:
+        logger.error(f"❌ 상벌점 대량 부여 실패: {e}")
+        error_message = getattr(e, "message", str(e))
+        return None, error_message

--- a/src/services/rollcall_service.py
+++ b/src/services/rollcall_service.py
@@ -1,0 +1,206 @@
+"""
+점호 관련 비즈니스 로직을 처리하는 서비스입니다.
+"""
+
+import logging
+from typing import Optional
+from src.utils.supabase_client import get_supabase_client
+
+# 로거 설정
+logger = logging.getLogger()
+logger.setLevel(logging.INFO)
+
+
+def get_rollcalls(
+    date: Optional[str] = None,
+    room_id: Optional[int] = None,
+    name: Optional[str] = None,
+    present: Optional[bool] = None,
+):
+    """
+    필터링된 점호 기록을 조회합니다.
+    다른 스키마 간 JOIN이 불가능하므로, room_id나 name 필터가 있으면
+    먼저 core.students에서 student_no 목록을 조회한 후 필터링합니다.
+    """
+    try:
+        supabase_rollcall = get_supabase_client("rollcall")
+        supabase_core = get_supabase_client("core")
+        if not supabase_rollcall or not supabase_core:
+            return None, "Supabase client could not be initialized."
+
+        logger.info("점호 기록 조회 시작")
+
+        # room_id나 name 필터가 있으면 먼저 학생 목록 조회
+        student_nos = None
+        if room_id or name:
+            student_query = (
+                supabase_core.postgrest.schema("core")
+                .from_("students")
+                .select("studentNo")
+            )
+            if room_id:
+                student_query = student_query.eq("room_number", room_id)
+            if name:
+                student_query = student_query.ilike("name", f"%{name}%")
+
+            student_response = student_query.execute()
+            student_nos = [s["studentNo"] for s in student_response.data]
+
+            if not student_nos:
+                # 조건에 맞는 학생이 없으면 빈 결과 반환
+                logger.info("조건에 맞는 학생이 없어 빈 결과를 반환합니다.")
+                return [], None
+
+        # rollcall.records 조회 (JOIN 제거)
+        query = (
+            supabase_rollcall.postgrest.schema("rollcall")
+            .from_("records")
+            .select("id, student_no, date, present, note, created_at, updated_at")
+        )
+
+        # 필터링 적용
+        if date:
+            query = query.eq("date", date)
+        if present is not None:
+            query = query.eq("present", present)
+        if student_nos:
+            query = query.in_("student_no", student_nos)
+
+        response = query.order("date", desc=True).order("id", desc=True).execute()
+
+        data = response.data
+        logger.info(f"✅ {len(data)}개의 점호 기록을 조회했습니다.")
+
+        return data, None
+
+    except Exception as e:
+        logger.error(f"❌ 점호 기록 조회 실패: {e}")
+        error_message = getattr(e, "message", str(e))
+        return None, error_message
+
+
+def create_or_update_rollcall(
+    student_no: str, date: str, present: bool, note: Optional[str] = None
+):
+    """
+    점호 기록을 생성하거나 수정합니다 (Upsert).
+    (student_no, date) 조합이 이미 존재하면 UPDATE, 없으면 INSERT합니다.
+    """
+    try:
+        supabase = get_supabase_client("rollcall")
+        if not supabase:
+            return None, "Supabase client could not be initialized."
+
+        logger.info(
+            f"점호 기록 Upsert 시작: student_no={student_no}, date={date}, present={present}"
+        )
+
+        # Upsert 데이터 준비
+        upsert_data = {
+            "student_no": student_no,
+            "date": date,
+            "present": present,
+            "note": note or "",
+        }
+
+        # Supabase의 upsert 메서드 사용 (ON CONFLICT 처리)
+        response = (
+            supabase.postgrest.schema("rollcall")
+            .from_("records")
+            .upsert(upsert_data, on_conflict="student_no,date")
+            .execute()
+        )
+
+        data = response.data
+        if data:
+            logger.info(
+                f"✅ 점호 기록 Upsert 성공: student_no={student_no}, date={date}"
+            )
+            return data[0], None
+        else:
+            logger.error("❌ 점호 기록 Upsert 실패: 응답 데이터가 없습니다.")
+            return None, "Failed to upsert rollcall record"
+
+    except Exception as e:
+        logger.error(f"❌ 점호 기록 Upsert 실패: {e}")
+        error_message = getattr(e, "message", str(e))
+        return None, error_message
+
+
+def update_rollcall(
+    id: int, present: Optional[bool] = None, note: Optional[str] = None
+):
+    """
+    점호 기록을 부분 수정합니다.
+    """
+    try:
+        supabase = get_supabase_client("rollcall")
+        if not supabase:
+            return None, "Supabase client could not be initialized."
+
+        logger.info(f"점호 기록 수정 시작: id={id}")
+
+        # 업데이트할 필드만 구성
+        update_data = {}
+        if present is not None:
+            update_data["present"] = present
+        if note is not None:
+            update_data["note"] = note
+
+        if not update_data:
+            logger.warning("업데이트할 유효한 필드가 없습니다.")
+            return None, "No valid fields to update"
+
+        response = (
+            supabase.postgrest.schema("rollcall")
+            .from_("records")
+            .update(update_data)
+            .eq("id", id)
+            .execute()
+        )
+
+        data = response.data
+        if data:
+            logger.info(f"✅ 점호 기록 수정 성공: id={id}")
+            return data[0], None
+        else:
+            logger.info(f"❌ 점호 기록을 찾을 수 없습니다: id={id}")
+            return None, "Not found"
+
+    except Exception as e:
+        logger.error(f"❌ 점호 기록 수정 실패: {e}")
+        error_message = getattr(e, "message", str(e))
+        return None, error_message
+
+
+def delete_rollcall(id: int):
+    """
+    점호 기록을 삭제합니다.
+    """
+    try:
+        supabase = get_supabase_client("rollcall")
+        if not supabase:
+            return None, "Supabase client could not be initialized."
+
+        logger.info(f"점호 기록 삭제 시작: id={id}")
+
+        response = (
+            supabase.postgrest.schema("rollcall")
+            .from_("records")
+            .delete()
+            .eq("id", id)
+            .execute()
+        )
+
+        data = response.data
+        if data:
+            logger.info(f"✅ 점호 기록 삭제 성공: id={id}")
+            return data[0], None
+        else:
+            logger.info(f"❌ 점호 기록을 찾을 수 없습니다: id={id}")
+            return None, "Not found"
+
+    except Exception as e:
+        logger.error(f"❌ 점호 기록 삭제 실패: {e}")
+        error_message = getattr(e, "message", str(e))
+        return None, error_message

--- a/src/services/rollcall_service.py
+++ b/src/services/rollcall_service.py
@@ -26,7 +26,7 @@ def get_rollcalls(
         supabase_rollcall = get_supabase_client("rollcall")
         supabase_core = get_supabase_client("core")
         if not supabase_rollcall or not supabase_core:
-            return None, "Supabase client could not be initialized."
+            raise RuntimeError("Supabase client could not be initialized.")
 
         logger.info("점호 기록 조회 시작")
 
@@ -49,7 +49,7 @@ def get_rollcalls(
             if not student_nos:
                 # 조건에 맞는 학생이 없으면 빈 결과 반환
                 logger.info("조건에 맞는 학생이 없어 빈 결과를 반환합니다.")
-                return [], None
+                return []
 
         # rollcall.records 조회 (JOIN 제거)
         query = (
@@ -71,12 +71,14 @@ def get_rollcalls(
         data = response.data
         logger.info(f"✅ {len(data)}개의 점호 기록을 조회했습니다.")
 
-        return data, None
+        return data
 
+    except RuntimeError:
+        # RuntimeError는 그대로 전파
+        raise
     except Exception as e:
-        logger.error(f"❌ 점호 기록 조회 실패: {e}")
-        error_message = getattr(e, "message", str(e))
-        return None, error_message
+        # 기타 예외는 RuntimeError로 변환하여 전파
+        raise RuntimeError(f"Failed to get rollcalls: {str(e)}")
 
 
 def create_or_update_rollcall(
@@ -86,45 +88,38 @@ def create_or_update_rollcall(
     점호 기록을 생성하거나 수정합니다 (Upsert).
     (student_no, date) 조합이 이미 존재하면 UPDATE, 없으면 INSERT합니다.
     """
-    try:
-        supabase = get_supabase_client("rollcall")
-        if not supabase:
-            return None, "Supabase client could not be initialized."
+    supabase = get_supabase_client("rollcall")
+    if not supabase:
+        raise RuntimeError("Supabase client could not be initialized.")
 
-        logger.info(
-            f"점호 기록 Upsert 시작: student_no={student_no}, date={date}, present={present}"
+    logger.info(
+        f"점호 기록 Upsert 시작: student_no={student_no}, date={date}, present={present}"
+    )
+
+    # Upsert 데이터 준비
+    upsert_data = {
+        "student_no": student_no,
+        "date": date,
+        "present": present,
+        "note": note or "",
+    }
+
+    # Supabase의 upsert 메서드 사용 (ON CONFLICT 처리)
+    response = (
+        supabase.postgrest.schema("rollcall")
+        .from_("records")
+        .upsert(upsert_data, on_conflict="student_no,date")
+        .execute()
+    )
+
+    data = response.data
+    if not data:
+        raise RuntimeError(
+            "Failed to upsert rollcall record: No data returned from database"
         )
 
-        # Upsert 데이터 준비
-        upsert_data = {
-            "student_no": student_no,
-            "date": date,
-            "present": present,
-            "note": note or "",
-        }
-
-        # Supabase의 upsert 메서드 사용 (ON CONFLICT 처리)
-        response = (
-            supabase.postgrest.schema("rollcall")
-            .from_("records")
-            .upsert(upsert_data, on_conflict="student_no,date")
-            .execute()
-        )
-
-        data = response.data
-        if data:
-            logger.info(
-                f"✅ 점호 기록 Upsert 성공: student_no={student_no}, date={date}"
-            )
-            return data[0], None
-        else:
-            logger.error("❌ 점호 기록 Upsert 실패: 응답 데이터가 없습니다.")
-            return None, "Failed to upsert rollcall record"
-
-    except Exception as e:
-        logger.error(f"❌ 점호 기록 Upsert 실패: {e}")
-        error_message = getattr(e, "message", str(e))
-        return None, error_message
+    logger.info(f"✅ 점호 기록 Upsert 성공: student_no={student_no}, date={date}")
+    return data[0]
 
 
 def update_rollcall(
@@ -133,74 +128,59 @@ def update_rollcall(
     """
     점호 기록을 부분 수정합니다.
     """
-    try:
-        supabase = get_supabase_client("rollcall")
-        if not supabase:
-            return None, "Supabase client could not be initialized."
+    supabase = get_supabase_client("rollcall")
+    if not supabase:
+        raise RuntimeError("Supabase client could not be initialized.")
 
-        logger.info(f"점호 기록 수정 시작: id={id}")
+    logger.info(f"점호 기록 수정 시작: id={id}")
 
-        # 업데이트할 필드만 구성
-        update_data = {}
-        if present is not None:
-            update_data["present"] = present
-        if note is not None:
-            update_data["note"] = note
+    # 업데이트할 필드만 구성
+    update_data = {}
+    if present is not None:
+        update_data["present"] = present
+    if note is not None:
+        update_data["note"] = note
 
-        if not update_data:
-            logger.warning("업데이트할 유효한 필드가 없습니다.")
-            return None, "No valid fields to update"
+    if not update_data:
+        raise ValueError("No valid fields to update")
 
-        response = (
-            supabase.postgrest.schema("rollcall")
-            .from_("records")
-            .update(update_data)
-            .eq("id", id)
-            .execute()
-        )
+    response = (
+        supabase.postgrest.schema("rollcall")
+        .from_("records")
+        .update(update_data)
+        .eq("id", id)
+        .execute()
+    )
 
-        data = response.data
-        if data:
-            logger.info(f"✅ 점호 기록 수정 성공: id={id}")
-            return data[0], None
-        else:
-            logger.info(f"❌ 점호 기록을 찾을 수 없습니다: id={id}")
-            return None, "Not found"
+    data = response.data
+    if not data:
+        raise RuntimeError(f"Rollcall not found: id={id}")
 
-    except Exception as e:
-        logger.error(f"❌ 점호 기록 수정 실패: {e}")
-        error_message = getattr(e, "message", str(e))
-        return None, error_message
+    logger.info(f"✅ 점호 기록 수정 성공: id={id}")
+    return data[0]
 
 
 def delete_rollcall(id: int):
     """
     점호 기록을 삭제합니다.
     """
-    try:
-        supabase = get_supabase_client("rollcall")
-        if not supabase:
-            return None, "Supabase client could not be initialized."
+    supabase = get_supabase_client("rollcall")
+    if not supabase:
+        raise RuntimeError("Supabase client could not be initialized.")
 
-        logger.info(f"점호 기록 삭제 시작: id={id}")
+    logger.info(f"점호 기록 삭제 시작: id={id}")
 
-        response = (
-            supabase.postgrest.schema("rollcall")
-            .from_("records")
-            .delete()
-            .eq("id", id)
-            .execute()
-        )
+    response = (
+        supabase.postgrest.schema("rollcall")
+        .from_("records")
+        .delete()
+        .eq("id", id)
+        .execute()
+    )
 
-        data = response.data
-        if data:
-            logger.info(f"✅ 점호 기록 삭제 성공: id={id}")
-            return data[0], None
-        else:
-            logger.info(f"❌ 점호 기록을 찾을 수 없습니다: id={id}")
-            return None, "Not found"
+    data = response.data
+    if not data:
+        raise RuntimeError(f"Rollcall not found: id={id}")
 
-    except Exception as e:
-        logger.error(f"❌ 점호 기록 삭제 실패: {e}")
-        error_message = getattr(e, "message", str(e))
-        return None, error_message
+    logger.info(f"✅ 점호 기록 삭제 성공: id={id}")
+    return data[0]

--- a/src/utils/routing.py
+++ b/src/utils/routing.py
@@ -15,6 +15,10 @@ MODULE_MAP: Dict[str, str] = {
     "notifications": "notifications_handler",
     "overnight-stay": "overnight_stays_handler",
     "overnight-stays": "overnight_stays_handler",
+    "rollcalls": "rollcall_handler",
+    "rollcall": "rollcall_handler",
+    "points": "point_handler",
+    "point": "point_handler",
 }
 
 # 2) 예외 라우팅: (METHOD, path_after_api)
@@ -43,6 +47,10 @@ ROUTE_OVERRIDES: Dict[Tuple[str, str], Tuple[str, str]] = {
         "send_individual_notification_handler",
     ),
     ("GET", "notices/filter"): ("notices_handler", "filter"),
+    ("GET", "rollcalls"): ("rollcall_handler", "get_rollcalls"),
+    ("GET", "points"): ("point_handler", "get_points"),
+    ("POST", "points"): ("point_handler", "create_point"),
+    ("POST", "points/bulk"): ("point_handler", "bulk_create_points"),
 }
 
 # 3) 기본 함수 규칙: (METHOD, resource) → function name
@@ -67,6 +75,9 @@ DEFAULT_FUNC_RULES: Dict[Tuple[str, str], str] = {
     ("GET", "overnight-stay"): "get_student_requests",
     ("GET", "overnight-stays"): "get_admin_requests",
     ("PATCH", "overnight-stays"): "update_status",
+    ("POST", "rollcall"): "create_or_update_rollcall",
+    ("PATCH", "rollcall"): "update_rollcall",
+    ("DELETE", "rollcall"): "delete_rollcall",
 }
 
 


### PR DESCRIPTION
## 변경사항

### 1. 점호(Rollcall) API 추가
- **GET /api/rollcalls** - 점호 기록 목록 조회
  - 쿼리 파라미터: `date`, `roomId`, `name`, `present` (모두 선택사항)
  - 날짜, 호실, 학생 이름, 출석 여부로 필터링 가능
  
- **POST /api/rollcall** - 점호 기록 생성/수정 (Upsert)
  - 같은 학생의 같은 날짜에 이미 기록이 있으면 수정, 없으면 생성
  - Request body: `studentId`, `date`, `present`, `note` (선택)
  
- **PATCH /api/rollcall** - 점호 기록 부분 수정
  - Request body: `id` (필수), `present`, `note` (선택사항)
  
- **DELETE /api/rollcall** - 점호 기록 삭제
  - 쿼리 파라미터: `id` (필수)

### 2. 상벌점(Point) API 추가
- **GET /api/points** - 상벌점 목록 조회
  - 쿼리 파라미터: `studentId`, `dateFrom`, `dateTo` (모두 선택사항)
  - 학생별, 기간별 필터링 가능
  
- **POST /api/points** - 상벌점 단일 생성
  - Request body: `studentId`, `type`, `score`, `reason`, `date` (모두 필수)
  
- **POST /api/points/bulk** - 상벌점 일괄 생성
  - Request body: `points` (배열)

### 3. 라우팅 설정
- `routing.py`에 rollcall 및 point 라우팅 규칙 추가
- 단수형/복수형 리소스 명명 규칙 적용
  - GET은 복수형 (`/rollcalls`, `/points`)
  - POST/PATCH/DELETE는 단수형 (`/rollcall`, `/point`)