### PR TITLE
feat: 캘린더 API 월별 조회 기능 추가

### DIFF
--- a/docs/openapi.yml
+++ b/docs/openapi.yml
@@ -752,7 +752,11 @@ paths:
   /api/calendar:
     get:
       summary: 캘린더 일정 조회
-      description: 전체 또는 특정 날짜의 캘린더 일정을 조회합니다.
+      description: |
+        전체, 특정 날짜, 또는 특정 월의 캘린더 일정을 조회합니다.
+        - date 파라미터가 있으면 해당 날짜의 일정만 조회합니다.
+        - year와 month 파라미터가 함께 제공되면 해당 월의 모든 일정을 조회합니다.
+        - 파라미터가 없으면 전체 일정을 조회합니다.
       tags:
         - Calendar
       parameters:
@@ -764,6 +768,20 @@ paths:
             type: string
             format: date
           example: "2025-09-19"
+        - name: year
+          in: query
+          description: 조회할 연도 (year와 month는 함께 제공되어야 함)
+          required: false
+          schema:
+            type: integer
+          example: 2025
+        - name: month
+          in: query
+          description: 조회할 월 (1-12, year와 month는 함께 제공되어야 함)
+          required: false
+          schema:
+            type: integer
+          example: 9
       responses:
         "200":
           description: 성공적으로 캘린더 일정을 반환했습니다.
@@ -772,7 +790,7 @@ paths:
               schema:
                 $ref: "#/components/schemas/CalendarList"
         "400":
-          description: 잘못된 요청 (잘못된 날짜 형식)
+          description: 잘못된 요청 (잘못된 날짜 형식, year와 month가 함께 제공되지 않음, month 범위 오류 등)
           content:
             application/json:
               schema:

--- a/src/handlers/calendar_handler.py
+++ b/src/handlers/calendar_handler.py
@@ -17,16 +17,20 @@ logger = logging.getLogger(__name__)
 def get_all(event, context):
     """
     GET /calendar API 요청을 처리하는 핸들러
-    query parameter date(선택): YYYY-MM-DD 형식으로 특정 날짜 조회
+    query parameter:
+    - date(선택): YYYY-MM-DD 형식으로 특정 날짜 조회
+    - year, month(선택): 특정 연도-월의 모든 일정 조회 (year와 month는 함께 제공되어야 함)
     """
     logger.info("✅ Processing get_all calendar request")
 
     try:
-        # 쿼리 파라미터에서 date 추출
+        # 쿼리 파라미터 추출
         query_params = event.get("queryStringParameters") or {}
         date = query_params.get("date")
+        year_str = query_params.get("year")
+        month_str = query_params.get("month")
 
-        # 날짜 형식 검증 (제공된 경우에만)
+        # date 파라미터가 있으면 기존 로직 사용 (우선순위 1)
         if date:
             date_pattern = r"^\d{4}-\d{2}-\d{2}$"
             if not re.match(date_pattern, date):
@@ -34,8 +38,50 @@ def get_all(event, context):
                     "Date must be in YYYY-MM-DD format.", 400
                 )
 
-        # 서비스 호출
-        calendar_data, error = calendar_service.get_calendar(date=date)
+            # 서비스 호출 (date만 사용)
+            calendar_data, error = calendar_service.get_calendar(date=date)
+            if error:
+                return responses.create_error_response(error, 500)
+
+            # DTO를 사용하여 응답 데이터 변환
+            calendar_list_dto = CalendarListDTO.from_supabase_data(calendar_data)
+            return responses.create_success_response(calendar_list_dto.to_dict())
+
+        # year와 month 파라미터 처리 (우선순위 2)
+        year = None
+        month = None
+
+        if year_str or month_str:
+            # year와 month는 함께 제공되어야 함
+            if not year_str or not month_str:
+                return responses.create_error_response(
+                    "Both year and month must be provided together.", 400
+                )
+
+            # year 검증
+            try:
+                year = int(year_str)
+                if year <= 0:
+                    return responses.create_error_response(
+                        "Year must be a positive integer.", 400
+                    )
+            except (ValueError, TypeError):
+                return responses.create_error_response("Invalid year format.", 400)
+
+            # month 검증
+            try:
+                month = int(month_str)
+                if not (1 <= month <= 12):
+                    return responses.create_error_response(
+                        "Month must be between 1 and 12.", 400
+                    )
+            except (ValueError, TypeError):
+                return responses.create_error_response("Invalid month format.", 400)
+
+        # 서비스 호출 (year, month 또는 둘 다 None)
+        calendar_data, error = calendar_service.get_calendar(
+            date=None, year=year, month=month
+        )
 
         if error:
             return responses.create_error_response(error, 500)

--- a/src/services/calendar_service.py
+++ b/src/services/calendar_service.py
@@ -1,21 +1,29 @@
 import logging
+import calendar
+from typing import Optional
 from src.utils.supabase_client import get_supabase_client
 
 # 로거 설정
 logger = logging.getLogger(__name__)
 
 
-def get_calendar(date: str = None):
+def get_calendar(
+    date: Optional[str] = None, year: Optional[int] = None, month: Optional[int] = None
+):
     """
     Supabase 클라이언트를 사용하여 캘린더 데이터를 가져옵니다.
-    date가 제공되면 특정 날짜의 데이터만 조회합니다.
+    - date가 제공되면 특정 날짜의 데이터만 조회합니다.
+    - year와 month가 제공되면 해당 월의 모든 데이터를 조회합니다.
+    - 모두 제공되지 않으면 전체 데이터를 조회합니다.
     """
     try:
         supabase = get_supabase_client("core")
         if not supabase:
             return None, "Supabase client could not be initialized."
 
-        logger.info(f"Supabase 'calendar' 테이블 조회 시작 - date: {date}")
+        logger.info(
+            f"Supabase 'calendar' 테이블 조회 시작 - date: {date}, year: {year}, month: {month}"
+        )
 
         # 기본 쿼리 구성
         query = (
@@ -24,9 +32,20 @@ def get_calendar(date: str = None):
             .select("id, date, roll_call_type, payment_type, created_at")
         )
 
-        # 특정 날짜 필터링 (선택적)
+        # 특정 날짜 필터링 (우선순위 1)
         if date:
             query = query.eq("date", date)
+            logger.info(f"특정 날짜 필터 적용: {date}")
+        # 월별 필터링 (우선순위 2)
+        elif year is not None and month is not None:
+            # 해당 월의 시작일과 종료일 계산
+            start_date = f"{year:04d}-{month:02d}-01"
+            # 해당 월의 마지막 날짜 계산
+            _, last_day = calendar.monthrange(year, month)
+            end_date = f"{year:04d}-{month:02d}-{last_day:02d}"
+
+            query = query.gte("date", start_date).lte("date", end_date)
+            logger.info(f"월별 필터 적용: {start_date} ~ {end_date}")
 
         # 날짜 순으로 정렬
         response = query.order("date").execute()


### PR DESCRIPTION
### 변경 사항
- `GET /api/calendar` 엔드포인트에 `year`, `month` 쿼리 파라미터 추가
- 특정 월의 모든 일정을 조회할 수 있는 기능 구현
- 기존 `date` 파라미터 기능 유지 (하위 호환성 보장)

### 구현 내용
1. **핸들러**: `year`, `month` 파라미터 처리 및 검증 로직 추가
2. **서비스**: 월별 필터링 로직 구현 (해당 월의 시작일~종료일 범위 조회)
3. **문서**: OpenAPI  docs 스펙 업데이트